### PR TITLE
Fix thumbnail helper typo

### DIFF
--- a/src/components/menu/bookmarkedEvent/BookmarkedEventPopover.vue
+++ b/src/components/menu/bookmarkedEvent/BookmarkedEventPopover.vue
@@ -2,7 +2,7 @@
 import { computed, onMounted } from "vue";
 import type { LiverEvent } from "@/services/api";
 import { scrollToLiverEventTop } from "@/lib/scroll";
-import { getThumnail } from "@/lib/youtube";
+import { getThumbnail } from "@/lib/youtube";
 import { useBookmarkStore } from "@/store/bookmarkStore";
 import { useDateStore } from "@/store/dateStore";
 import { useFocusStore } from "@/store/focusStore";
@@ -83,7 +83,7 @@ onMounted(() => {
         >
           <div class="flex items-center gap-2 p-2 text-start">
             <img
-              :src="getThumnail(liverEvent.thumbnail, 'mq')"
+              :src="getThumbnail(liverEvent.thumbnail, 'mq')"
               class="_thumb aspect-video h-[36px] w-[64px] bg-gray-800 object-cover p-0 transition-colors"
               loading="lazy"
             />

--- a/src/components/streams/LiverEventCard.vue
+++ b/src/components/streams/LiverEventCard.vue
@@ -2,7 +2,7 @@
 import { computed, toRaw, toRefs } from "vue";
 import { useLiverEvent } from "./useLiverEvent";
 import type { LiverEvent } from "@/services/api";
-import { getThumnail } from "@/lib/youtube";
+import { getThumbnail } from "@/lib/youtube";
 import { useFocusStore } from "@/store/focusStore";
 import { useSearchStore } from "@/store/searchStore";
 import { hhss } from "@/utils/dateFormat";
@@ -158,7 +158,7 @@ function setSearchString(str: string) {
 
         <div class="flex aspect-video h-full overflow-hidden max-sm:w-[clamp(140px,30vw,200px)]">
           <img
-            :src="getThumnail(liverEvent.thumbnail, 'mq')"
+            :src="getThumbnail(liverEvent.thumbnail, 'mq')"
             class="size-full object-cover transition-transform group-hover:scale-110"
             loading="lazy"
           />

--- a/src/components/streams/detail/LiverEventDetailPopover.vue
+++ b/src/components/streams/detail/LiverEventDetailPopover.vue
@@ -4,7 +4,7 @@ import { useLiverEvent } from "../useLiverEvent";
 import type { LiverEvent } from "@/services/api";
 import { usePopover } from "@/composable/usePopover";
 import { parseSegment } from "@/lib/text";
-import { getThumnail } from "@/lib/youtube";
+import { getThumbnail } from "@/lib/youtube";
 import { useBookmarkStore } from "@/store/bookmarkStore";
 import { useFocusStore } from "@/store/focusStore";
 import { useNotificationStore } from "@/store/notificationStore";
@@ -94,7 +94,7 @@ async function onClickNotify(id: string) {
 
     <a :href="liverEvent.url" target="_blank">
       <img
-        :src="getThumnail(liverEvent.thumbnail, 'sd')"
+        :src="getThumbnail(liverEvent.thumbnail, 'sd')"
         class="_thumb [@starting-style:opacity-0] aspect-video w-[480px] bg-gray-800 object-cover p-0 transition-colors"
         loading="lazy"
       />

--- a/src/lib/youtube.ts
+++ b/src/lib/youtube.ts
@@ -6,9 +6,9 @@ type YoutubeImageQuality = "" | "mq" | "hq" | "sd" | "maxres";
  * @param quality Thumbnail quality
  * @returns Thumbnail url with quality
  * @example
- * getThumnail("https://i.ytimg.com/vi/VIDEO_ID/default.jpg", "hq") // "https://i.ytimg.com/vi/VIDEO_ID/hqdefault.jpg"
+ * getThumbnail("https://i.ytimg.com/vi/VIDEO_ID/default.jpg", "hq") // "https://i.ytimg.com/vi/VIDEO_ID/hqdefault.jpg"
  */
-export function getThumnail(url: string, quality: YoutubeImageQuality) {
+export function getThumbnail(url: string, quality: YoutubeImageQuality) {
   const groups = url.match(/^(?<base>.+\/)(.*default)(?<filename>(_live)?\..+)$/)?.groups;
   if (!groups) return url;
 


### PR DESCRIPTION
## Summary
- rename `getThumnail` to `getThumbnail`
- update usage across components

## Testing
- `npm test` *(fails: vitest not found)*
- `npm run lint` *(fails: Invalid option '--ignore-path')*