### PR TITLE
Add getThumbnail tests

### DIFF
--- a/src/lib/youtube.test.ts
+++ b/src/lib/youtube.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { getYouTubeVideoId } from "./youtube";
+import { getYouTubeVideoId, getThumbnail } from "./youtube";
 
 describe("getYouTubeVideoId", () => {
   it("should return the video ID from a standard YouTube URL", () => {
@@ -41,5 +41,48 @@ describe("getYouTubeVideoId", () => {
     const url = "https://www.youtube.com/watch?v=VIDEO_ID&feature=youtu.be";
     const expected = "VIDEO_ID";
     expect(getYouTubeVideoId(url)).toBe(expected);
+  });
+});
+
+describe("getThumbnail", () => {
+  it("returns mq quality thumbnail url", () => {
+    const url = "https://i.ytimg.com/vi/VIDEO_ID/default.jpg";
+    const expected = "https://i.ytimg.com/vi/VIDEO_ID/mqdefault.jpg";
+    expect(getThumbnail(url, "mq")).toBe(expected);
+  });
+
+  it("returns hq quality thumbnail url", () => {
+    const url = "https://i.ytimg.com/vi/VIDEO_ID/default.jpg";
+    const expected = "https://i.ytimg.com/vi/VIDEO_ID/hqdefault.jpg";
+    expect(getThumbnail(url, "hq")).toBe(expected);
+  });
+
+  it("returns sd quality thumbnail url", () => {
+    const url = "https://i.ytimg.com/vi/VIDEO_ID/default.jpg";
+    const expected = "https://i.ytimg.com/vi/VIDEO_ID/sddefault.jpg";
+    expect(getThumbnail(url, "sd")).toBe(expected);
+  });
+
+  it("returns maxres quality thumbnail url", () => {
+    const url = "https://i.ytimg.com/vi/VIDEO_ID/default.jpg";
+    const expected = "https://i.ytimg.com/vi/VIDEO_ID/maxresdefault.jpg";
+    expect(getThumbnail(url, "maxres")).toBe(expected);
+  });
+
+  it("keeps url unchanged for empty quality", () => {
+    const url = "https://i.ytimg.com/vi/VIDEO_ID/default.jpg";
+    const expected = "https://i.ytimg.com/vi/VIDEO_ID/default.jpg";
+    expect(getThumbnail(url, "")).toBe(expected);
+  });
+
+  it("handles live thumbnails", () => {
+    const url = "https://i.ytimg.com/vi/VIDEO_ID/default_live.jpg";
+    const expected = "https://i.ytimg.com/vi/VIDEO_ID/hqdefault_live.jpg";
+    expect(getThumbnail(url, "hq")).toBe(expected);
+  });
+
+  it("returns original url when parsing fails", () => {
+    const url = "https://example.com/image.jpg";
+    expect(getThumbnail(url, "hq")).toBe(url);
   });
 });


### PR DESCRIPTION
## Summary
- add test coverage for `getThumbnail` inside `youtube.test.ts`
- remove the now redundant `getThumbnail.test.ts`

## Testing
- `npm test` *(fails: vitest not found)*