### PR TITLE
dateStoreにuseIntervalFnを採用

### DIFF
--- a/src/store/dateStore.ts
+++ b/src/store/dateStore.ts
@@ -1,3 +1,4 @@
+import { useIntervalFn } from "@vueuse/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
 import { getDateTime, getHourTime } from "@/utils/date";
@@ -5,7 +6,7 @@ import { getDateTime, getHourTime } from "@/utils/date";
 export const useDateStore = defineStore("dateStore", () => {
   const currentDate = ref(new Date());
 
-  setInterval(() => {
+  useIntervalFn(() => {
     currentDate.value = new Date();
   }, 5000);
 


### PR DESCRIPTION
## 概要
`dateStore` の更新タイマーを VueUse の `useIntervalFn` で実装し直しました。`useIntervalFn` は自動で破棄処理を行うため、`onScopeDispose` での `clearInterval` が不要になります。

## テスト結果
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm vitest run`
