### PR TITLE
日付ユーティリティを section.ts に導入

### DIFF
--- a/src/lib/section.test.ts
+++ b/src/lib/section.test.ts
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { createDateSectionList } from "./section";
+import type { LiverEvent } from "@/services/api";
+
+function createEvent(id: string, startAt: string): LiverEvent {
+  return {
+    id,
+    title: "",
+    url: "",
+    thumbnail: "",
+    startAt: new Date(startAt),
+    endAt: null,
+    isLive: false,
+    talent: { name: `talent${id}`, image: "" },
+    collaboTalents: [],
+    affiliation: "hololive",
+    hashtagList: [],
+    hashtagSet: new Set(),
+    collaboTalentSet: new Set(),
+    keywordList: [],
+  };
+}
+
+describe("createDateSectionList", () => {
+  it("日時ごとにイベントをグループ化する", () => {
+    const events: LiverEvent[] = [
+      createEvent("1", "2024-01-01T00:10:00Z"),
+      createEvent("2", "2024-01-01T01:20:00Z"),
+      createEvent("3", "2024-01-02T00:05:00Z"),
+    ];
+    const list = createDateSectionList(events);
+    expect(list.length).toBe(2);
+    const firstDay = list[0].timeSectionList;
+    const secondDay = list[1].timeSectionList;
+    expect(firstDay.find((s) => s.events.some((e) => e.id === "1"))).toBeDefined();
+    expect(firstDay.find((s) => s.events.some((e) => e.id === "2"))).toBeDefined();
+    expect(secondDay.find((s) => s.events.some((e) => e.id === "3"))).toBeDefined();
+  });
+});

--- a/src/lib/section.ts
+++ b/src/lib/section.ts
@@ -1,4 +1,5 @@
 import type { LiverEvent } from "@/services/api";
+import { getDateTime, getHourTime } from "@/utils/date";
 
 export interface DateSection {
   time: number;
@@ -15,15 +16,6 @@ export function createDateSectionList(liverEventList: LiverEvent[]): DateSection
   if (liverEventList.length === 0) return [];
   const firstEvent = liverEventList[0];
   const lastEvent = liverEventList[liverEventList.length - 1];
-
-  function getHourTime(date: Date): number {
-    const hour = date.getHours();
-    return new Date(date).setHours(hour, 0, 0, 0);
-  }
-
-  function getDateTime(date: Date): number {
-    return new Date(date).setHours(0, 0, 0, 0);
-  }
 
   const oneHour = 3600000;
   const oneDay = 86400000;


### PR DESCRIPTION
## 概要
- `src/lib/section.ts` 内で重複して実装されていた `getDateTime` と `getHourTime` を削除し、`src/utils/date.ts` からインポートするよう変更
- `createDateSectionList` の動作を確認するテスト `src/lib/section.test.ts` を追加

## テスト結果
- `pnpm vitest run`：すべて成功
- `pnpm run lint`：成功
- `pnpm run type-check`：成功