### PR TITLE
intervalをVueUseのものに差し替え

### DIFF
--- a/src/views/LiverStreamsView.vue
+++ b/src/views/LiverStreamsView.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useIntervalFn } from "@vueuse/core";
 import { onMounted } from "vue";
 import FooterMenu from "@/components/menu/FooterMenu.vue";
 import HeaderMenu from "@/components/menu/HeaderMenu.vue";
@@ -18,7 +19,7 @@ onMounted(async () => {
   const updateList = () => eventListStore.updateLiverEventList(nijiLiverMap);
 
   // 一定時間ごとにスケジュールを再取得
-  setInterval(updateList, fetchInterval);
+  useIntervalFn(updateList, fetchInterval);
 
   // 初回取得
   updateList();


### PR DESCRIPTION
## 概要
`LiverStreamsView.vue` の `useIntervalFn` 呼び出しから第3引数を削除しました。また、ESLint/Prettier の自動整形に合わせてインポート順を調整しました。

## テスト結果
- `pnpm vitest run`
- `pnpm run lint`
- `pnpm run type-check`
