### PR TITLE
refactor(renovate): 共有プリセットに切り出し

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,17 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:best-practices", ":pinDependencies"],
+  "extends": [
+    "config:best-practices",
+    ":pinDependencies",
+    "github>miyaoka/renovate-config"
+  ],
   "labels": ["dependencies"],
   "assignees": ["miyaoka"],
-  "reviewers": ["miyaoka"],
-  "lockFileMaintenance": {
-    "automerge": true
-  },
-  "packageRules": [
-    {
-      "description": "tsgo dev preview は日次更新のため auto-merge",
-      "matchPackageNames": ["@typescript/native-preview"],
-      "automerge": true
-    }
-  ]
+  "reviewers": ["miyaoka"]
 }


### PR DESCRIPTION
## 概要

Renovate の automerge 設定を共有プリセットリポジトリ（ miyaoka/renovate-config ）に切り出し、`extends` で参照する形に変更。

## 背景

lockFileMaintenance の automerge や tsgo dev preview の automerge ルールは、他のリポジトリでも同様に適用したい設定。リポジトリごとに同じ設定を書くのではなく、共有プリセットとして一元管理する。

## 変更内容

### renovate.json

- `lockFileMaintenance.automerge` と `packageRules`（tsgo preview automerge）をインラインから削除
- `extends` に `github>miyaoka/renovate-config` を追加

### 共有プリセットリポジトリ（別リポジトリ）

- miyaoka/renovate-config を新規作成し、`default.json` に切り出した設定を配置済み

## スコープ

- **スコープ内**: liver-streams の renovate.json を共有プリセット参照に切り替え
- **スコープ外（別 PR で対応）**: 他リポジトリへの共有プリセット適用

## 確認事項

- [ ] Renovate が正常に動作し、共有プリセットの設定が反映されること
