### PR TITLE
fix(nijisanji): handle null thumbnail from API

### DIFF
--- a/packages/core/src/lib/youtube.ts
+++ b/packages/core/src/lib/youtube.ts
@@ -27,8 +27,10 @@ export function getThumbnail(url: string, quality: YoutubeImageQuality) {
 // 埋め込みURL: https://www.youtube.com/embed/videoId
 // 短縮URL: https://www.youtube.com/v/videoId
 // ライブURL: https://www.youtube.com/live/videoId
+const youtubeHostPattern = /^https?:\/\/(?:www\.)?(?:youtube\.com|youtu\.be)\//;
 const videoIdPattern = /(?:v=|\/(?:embed|v|live)\/|youtu\.be\/)([0-9A-Za-z_-]+)/;
 export function getYouTubeVideoId(url: string): string | undefined {
+  if (!youtubeHostPattern.test(url)) return undefined;
   const videoId = url.match(videoIdPattern)?.[1];
   return videoId;
 }

--- a/packages/core/src/lib/youtube.ts
+++ b/packages/core/src/lib/youtube.ts
@@ -8,7 +8,12 @@ type YoutubeImageQuality = "" | "mq" | "hq" | "sd" | "maxres";
  * @example
  * getThumbnail("https://i.ytimg.com/vi/VIDEO_ID/default.jpg", "hq") // "https://i.ytimg.com/vi/VIDEO_ID/hqdefault.jpg"
  */
+export function getYouTubeThumbnailUrl(videoId: string): string {
+  return `https://i.ytimg.com/vi/${videoId}/sddefault.jpg`;
+}
+
 export function getThumbnail(url: string, quality: YoutubeImageQuality) {
+  if (!url) return "";
   const groups = url.match(/^(?<base>.+\/)(.*default)(?<filename>(_live)?\..+)$/)?.groups;
   if (!groups) return url;
 

--- a/packages/nijisanji/src/api.ts
+++ b/packages/nijisanji/src/api.ts
@@ -5,7 +5,8 @@ export interface NijiLiver {
 export interface NijiStream {
   title: string;
   url: string;
-  thumbnail: string;
+  // API が稀に null を返す
+  thumbnail: string | null;
   startAt: string;
   endAt: string | null;
   isLive: boolean;

--- a/packages/nijisanji/src/index.ts
+++ b/packages/nijisanji/src/index.ts
@@ -1,4 +1,4 @@
-import { createLiverEvent } from "@liver-streams/core";
+import { createLiverEvent, getYouTubeThumbnailUrl, getYouTubeVideoId } from "@liver-streams/core";
 import type {
   ChannelNode,
   EventService,
@@ -69,6 +69,14 @@ async function getNijiEvents({
     };
   }
 
+  // API が稀に thumbnail: null を返すため、YouTube URL から補完する
+  function resolveThumbnail(thumbnail: string | null, url: string): string {
+    if (thumbnail) return thumbnail;
+    const videoId = getYouTubeVideoId(url);
+    if (videoId) return getYouTubeThumbnailUrl(videoId);
+    return "";
+  }
+
   const events = nijiStreams.map(async (stream) => {
     const { title, url, thumbnail, startAt, endAt, isLive, talentId, collaboTalentIds } = stream;
     const talent = getTalent(talentId);
@@ -78,7 +86,7 @@ async function getNijiEvents({
       startAt,
       title,
       url,
-      thumbnail,
+      thumbnail: resolveThumbnail(thumbnail, url),
       endAt,
       isLive,
       talent,


### PR DESCRIPTION
## 概要

にじさんじ API が稀に `thumbnail: null` を返すストリームがあり、dev モードで配信一覧が表示されなくなる問題を修正する。

## 背景

dev サーバーでイベント一覧が表示されず、build → preview では正常に動作するという報告があった。

調査の結果、にじさんじ API のレスポンスで 221 件中 2 件が `thumbnail: null` を返しており、`getThumbnail()` 内で `null.match()` が TypeError を投げていた。Vue の dev モードでは render 中の例外がコンポーネントツリー全体をクラッシュさせるため一覧が消えるが、production モードでは該当カードだけスキップされるため見た目上は正常に動作していた。

公式サイト（nijisanji.jp/streams）は `fallback-thumbnail-url` フィールドを持っておりフォールバックしているが、プロキシ API はこのフィールドを返していない。

## 変更内容

### packages/nijisanji

- `NijiStream.thumbnail` の型を `string | null` に修正（実際の API レスポンスに合わせる）
- `resolveThumbnail()` を追加し、thumbnail が null のとき YouTube URL から動画 ID を抽出して `sddefault.jpg` を生成する

### packages/core

- `getYouTubeThumbnailUrl()` を追加（動画 ID からサムネイル URL を生成）
- `getThumbnail()` に空文字列ガードを追加
- `getYouTubeVideoId()` にホスト名チェックを追加（`youtube.com` / `youtu.be` 以外では動画 ID を抽出しない）

## 確認事項

- [ ] dev サーバーでイベント一覧が正常に表示されること
- [ ] thumbnail が null のストリームでもサムネイルが表示されること
