### PR TITLE
feat: add barrel-import plugin and knip for unused code detection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,8 +70,10 @@ packages/
 
 ### Git フック
 
-- lefthook でコミット前に自動整形
-- 対象ファイル: `*.{js,ts,vue,css,scss,md}`
+- lefthook でコミット前に自動整形・不要コード削除を実行
+- oxlint + eslint + oxfmt でリント・フォーマット（`stage_fixed` で自動ステージ）
+- knip --fix で未使用 export を自動削除（変更は unstaged で残るので、確認して git add → 再コミット）
+- フォーマットや不要 export の整理はコミットフックで自動的に行われるため、手動で実行しない
 
 ## Vue コンポーネント
 

--- a/apps/web/eslint.base.ts
+++ b/apps/web/eslint.base.ts
@@ -1,3 +1,4 @@
+import pluginBarrelImport from "@miyaoka/eslint-plugin-barrel-import";
 import type { ESLint, Linter } from "eslint";
 import pluginImportX from "eslint-plugin-import-x";
 import pluginUnusedImports from "eslint-plugin-unused-imports";
@@ -5,6 +6,7 @@ import pluginUnusedImports from "eslint-plugin-unused-imports";
 // 共有ルール設定（TypeScript 設定は各パッケージで行う）
 export const baseRules: Linter.Config = {
   plugins: {
+    "barrel-import": pluginBarrelImport,
     // eslint-plugin-import-x の型が @typescript-eslint/utils の型を使用しており、
     // ESLint の defineConfig 型と互換性がない (typescript-eslint/typescript-eslint#11543)
     "import-x": pluginImportX as unknown as ESLint.Plugin,
@@ -22,6 +24,23 @@ export const baseRules: Linter.Config = {
         args: "after-used",
         argsIgnorePattern: "^_",
         ignoreRestSiblings: true,
+      },
+    ],
+
+    // barrel-import
+    "barrel-import/barrel-import": [
+      "error",
+      {
+        scopes: {
+          shared: {
+            directories: ["shared"],
+            dependsOn: [],
+          },
+          features: {
+            directories: ["features"],
+            dependsOn: ["shared"],
+          },
+        },
       },
     ],
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -29,6 +29,7 @@
     "@iconify-json/icon-park-outline": "1.2.4",
     "@iconify-json/icon-park-solid": "1.2.4",
     "@iconify-json/mdi": "1.2.3",
+    "@miyaoka/eslint-plugin-barrel-import": "^0.0.0",
     "@miyaoka/vite-plugin-doc-block": "0.0.2",
     "@tailwindcss/vite": "4.2.4",
     "@tsconfig/node24": "catalog:",

--- a/apps/web/src/features/bookmark/BookmarkedEventButton.vue
+++ b/apps/web/src/features/bookmark/BookmarkedEventButton.vue
@@ -6,7 +6,7 @@
 import type { LiverEvent } from "@liver-streams/core";
 import { computed } from "vue";
 import { usePopover } from "../../shared/composables";
-import { useEventListStore } from "../../store/eventListStore";
+import { useEventListStore } from "../streams";
 import BookmarkedEventPopover from "./BookmarkedEventPopover.vue";
 import { useBookmarkStore } from "./";
 

--- a/apps/web/src/features/bookmark/BookmarkedEventButton.vue
+++ b/apps/web/src/features/bookmark/BookmarkedEventButton.vue
@@ -5,10 +5,10 @@
 <script setup lang="ts">
 import type { LiverEvent } from "@liver-streams/core";
 import { computed } from "vue";
-import { usePopover } from "../../shared/composables/usePopover";
+import { usePopover } from "../../shared/composables";
 import { useEventListStore } from "../../store/eventListStore";
 import BookmarkedEventPopover from "./BookmarkedEventPopover.vue";
-import { useBookmarkStore } from "./bookmarkStore";
+import { useBookmarkStore } from "./";
 
 const eventListStore = useEventListStore();
 const bookmarkStore = useBookmarkStore();

--- a/apps/web/src/features/bookmark/BookmarkedEventPopover.vue
+++ b/apps/web/src/features/bookmark/BookmarkedEventPopover.vue
@@ -14,11 +14,10 @@ import {
   toRelativeTime,
 } from "@liver-streams/core";
 import { computed, onMounted } from "vue";
-import { scrollToLiverEventTop } from "../../shared/lib/scroll";
-import { useDateStore } from "../../shared/stores/dateStore";
-import { useHoverStore } from "../../shared/stores/hoverStore";
-import { closePopover } from "../../shared/utils/popover";
-import { useBookmarkStore } from "./bookmarkStore";
+import { scrollToLiverEventTop } from "../../shared/lib";
+import { useDateStore, useHoverStore } from "../../shared/stores";
+import { closePopover } from "../../shared/utils";
+import { useBookmarkStore } from "./";
 
 const props = defineProps<{
   bookmarkEventList: LiverEvent[];

--- a/apps/web/src/features/bookmark/index.ts
+++ b/apps/web/src/features/bookmark/index.ts
@@ -1,0 +1,4 @@
+export { default as BookmarkedEventButton } from "./BookmarkedEventButton.vue";
+export { useBookmarkStore } from "./bookmarkStore";
+export { useNotificationStore } from "./notificationStore";
+export { processBookmarkNotification } from "./useBookmarkNotification";

--- a/apps/web/src/features/bookmark/useBookmarkNotification.ts
+++ b/apps/web/src/features/bookmark/useBookmarkNotification.ts
@@ -1,6 +1,6 @@
 import type { LiverEvent } from "@liver-streams/core";
 import { hhmmDateFormatter } from "@liver-streams/core";
-import { useBookmarkStore } from "./bookmarkStore";
+import { useBookmarkStore } from "./";
 
 export function processBookmarkNotification(liverEventMap: Map<string, LiverEvent>) {
   const bookmarkStore = useBookmarkStore();

--- a/apps/web/src/features/channelFilter/ChannelFilter.vue
+++ b/apps/web/src/features/channelFilter/ChannelFilter.vue
@@ -6,10 +6,10 @@
 import { hololiveChannels } from "@liver-streams/hololive";
 import { nijisanjiChannels } from "@liver-streams/nijisanji";
 import { computed, ref } from "vue";
-import { usePopover } from "../../shared/composables/usePopover";
+import { usePopover } from "../../shared/composables";
 import { getAffiliationLogo, services } from "../../shared/services";
 import ChannelNode from "./ChannelNode.vue";
-import { useTalentFilterStore } from "./talentFilterStore";
+import { useTalentFilterStore } from "./";
 
 const talentFilterStore = useTalentFilterStore();
 const popover = usePopover({

--- a/apps/web/src/features/channelFilter/ChannelNode.vue
+++ b/apps/web/src/features/channelFilter/ChannelNode.vue
@@ -7,8 +7,8 @@
 <script setup lang="ts">
 import type { ChannelNode, EventService } from "@liver-streams/core";
 import { computed, onMounted, ref } from "vue";
-import { useSearchStore } from "../../shared/stores/searchStore";
-import { useTalentFilterStore } from "./talentFilterStore";
+import { useSearchStore } from "../../shared/stores";
+import { useTalentFilterStore } from "./";
 
 const props = defineProps<{
   node: ChannelNode;

--- a/apps/web/src/features/channelFilter/index.ts
+++ b/apps/web/src/features/channelFilter/index.ts
@@ -1,3 +1,2 @@
 export { default as ChannelFilter } from "./ChannelFilter.vue";
 export { useTalentFilterStore } from "./talentFilterStore";
-export type { Node, TreeNode } from "./talentFilterStore";

--- a/apps/web/src/features/channelFilter/index.ts
+++ b/apps/web/src/features/channelFilter/index.ts
@@ -1,0 +1,3 @@
+export { default as ChannelFilter } from "./ChannelFilter.vue";
+export { useTalentFilterStore } from "./talentFilterStore";
+export type { Node, TreeNode } from "./talentFilterStore";

--- a/apps/web/src/features/channelFilter/talentFilterStore.ts
+++ b/apps/web/src/features/channelFilter/talentFilterStore.ts
@@ -2,13 +2,13 @@ import { useLocalStorage } from "@vueuse/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed } from "vue";
 
-export interface TreeNode {
+interface TreeNode {
   id: string;
   checked: boolean;
   children?: TreeNode[];
 }
 
-export interface Node {
+interface Node {
   [key: string]: string[] | Node;
 }
 

--- a/apps/web/src/features/common/index.ts
+++ b/apps/web/src/features/common/index.ts
@@ -1,0 +1,1 @@
+export { default as LoadingSpinner } from "./LoadingSpinner.vue";

--- a/apps/web/src/features/keyword/KeywordListButton.vue
+++ b/apps/web/src/features/keyword/KeywordListButton.vue
@@ -3,7 +3,7 @@
 </doc>
 
 <script setup lang="ts">
-import { usePopover } from "../../shared/composables/usePopover";
+import { usePopover } from "../../shared/composables";
 import KeywordListPopover from "./KeywordListPopover.vue";
 
 const popover = usePopover();

--- a/apps/web/src/features/keyword/KeywordListPopover.vue
+++ b/apps/web/src/features/keyword/KeywordListPopover.vue
@@ -9,8 +9,8 @@ import { getFilteredEventList } from "@liver-streams/core";
 import { computed } from "vue";
 import { useSearchStore } from "../../shared/stores";
 import { closePopover } from "../../shared/utils";
-import { useEventListStore } from "../../store/eventListStore";
 import { useTalentFilterStore } from "../channelFilter";
+import { useEventListStore } from "../streams";
 import KeywordListPopoverItem from "./KeywordListPopoverItem.vue";
 
 export interface KeywordItem {

--- a/apps/web/src/features/keyword/KeywordListPopover.vue
+++ b/apps/web/src/features/keyword/KeywordListPopover.vue
@@ -7,10 +7,10 @@
 <script setup lang="ts">
 import { getFilteredEventList } from "@liver-streams/core";
 import { computed } from "vue";
-import { useSearchStore } from "../../shared/stores/searchStore";
-import { closePopover } from "../../shared/utils/popover";
+import { useSearchStore } from "../../shared/stores";
+import { closePopover } from "../../shared/utils";
 import { useEventListStore } from "../../store/eventListStore";
-import { useTalentFilterStore } from "../channelFilter/talentFilterStore";
+import { useTalentFilterStore } from "../channelFilter";
 import KeywordListPopoverItem from "./KeywordListPopoverItem.vue";
 
 export interface KeywordItem {

--- a/apps/web/src/features/keyword/KeywordListPopoverItem.vue
+++ b/apps/web/src/features/keyword/KeywordListPopoverItem.vue
@@ -3,7 +3,7 @@
 </doc>
 
 <script setup lang="ts">
-import { useSearchStore } from "../../shared/stores/searchStore";
+import { useSearchStore } from "../../shared/stores";
 import type { KeywordItem } from "./KeywordListPopover.vue";
 
 defineProps<{

--- a/apps/web/src/features/keyword/index.ts
+++ b/apps/web/src/features/keyword/index.ts
@@ -1,0 +1,1 @@
+export { default as KeywordListButton } from "./KeywordListButton.vue";

--- a/apps/web/src/features/menu/FilteringButton.vue
+++ b/apps/web/src/features/menu/FilteringButton.vue
@@ -3,7 +3,7 @@
 </doc>
 
 <script setup lang="ts">
-import { useSearchStore } from "../../shared/stores/searchStore";
+import { useSearchStore } from "../../shared/stores";
 import { useEventListStore } from "../../store/eventListStore";
 
 const searchStore = useSearchStore();

--- a/apps/web/src/features/menu/FilteringButton.vue
+++ b/apps/web/src/features/menu/FilteringButton.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { useSearchStore } from "../../shared/stores";
-import { useEventListStore } from "../../store/eventListStore";
+import { useEventListStore } from "../streams";
 
 const searchStore = useSearchStore();
 const eventListStore = useEventListStore();

--- a/apps/web/src/features/menu/FooterMenu.vue
+++ b/apps/web/src/features/menu/FooterMenu.vue
@@ -9,12 +9,11 @@
 
 <script setup lang="ts">
 import { getYouTubeVideoId } from "@liver-streams/core";
-import { useMultiSelectStore } from "../../shared/stores/multiSelectStore";
-import { useSearchStore } from "../../shared/stores/searchStore";
+import { useMultiSelectStore, useSearchStore } from "../../shared/stores";
 import { useEventListStore } from "../../store/eventListStore";
-import BookmarkedEventButton from "../bookmark/BookmarkedEventButton.vue";
-import KeywordListButton from "../keyword/KeywordListButton.vue";
-import NewArrivalsButton from "../newArrivals/NewArrivalsButton.vue";
+import { BookmarkedEventButton } from "../bookmark";
+import { KeywordListButton } from "../keyword";
+import { NewArrivalsButton } from "../newArrivals";
 import FilteringButton from "./FilteringButton.vue";
 import LiveFilterButton from "./LiveFilterButton.vue";
 import MultiSelectButton from "./MultiSelectButton.vue";

--- a/apps/web/src/features/menu/FooterMenu.vue
+++ b/apps/web/src/features/menu/FooterMenu.vue
@@ -10,10 +10,10 @@
 <script setup lang="ts">
 import { getYouTubeVideoId } from "@liver-streams/core";
 import { useMultiSelectStore, useSearchStore } from "../../shared/stores";
-import { useEventListStore } from "../../store/eventListStore";
 import { BookmarkedEventButton } from "../bookmark";
 import { KeywordListButton } from "../keyword";
 import { NewArrivalsButton } from "../newArrivals";
+import { useEventListStore } from "../streams";
 import FilteringButton from "./FilteringButton.vue";
 import LiveFilterButton from "./LiveFilterButton.vue";
 import MultiSelectButton from "./MultiSelectButton.vue";

--- a/apps/web/src/features/menu/HeaderMenu.vue
+++ b/apps/web/src/features/menu/HeaderMenu.vue
@@ -3,8 +3,8 @@
 </doc>
 
 <script setup lang="ts">
-import ChannelFilter from "../channelFilter/ChannelFilter.vue";
-import SearchFilter from "../search/SearchFilter.vue";
+import { ChannelFilter } from "../channelFilter";
+import { SearchFilter } from "../search";
 </script>
 
 <template>

--- a/apps/web/src/features/menu/LiveFilterButton.vue
+++ b/apps/web/src/features/menu/LiveFilterButton.vue
@@ -5,7 +5,7 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useSearchStore } from "../../shared/stores";
-import { useEventListStore } from "../../store/eventListStore";
+import { useEventListStore } from "../streams";
 
 const searchStore = useSearchStore();
 const eventListStore = useEventListStore();

--- a/apps/web/src/features/menu/LiveFilterButton.vue
+++ b/apps/web/src/features/menu/LiveFilterButton.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { useSearchStore } from "../../shared/stores/searchStore";
+import { useSearchStore } from "../../shared/stores";
 import { useEventListStore } from "../../store/eventListStore";
 
 const searchStore = useSearchStore();

--- a/apps/web/src/features/menu/MultiSelectButton.vue
+++ b/apps/web/src/features/menu/MultiSelectButton.vue
@@ -3,7 +3,7 @@
 </doc>
 
 <script setup lang="ts">
-import { useMultiSelectStore } from "../../shared/stores/multiSelectStore";
+import { useMultiSelectStore } from "../../shared/stores";
 
 const multiSelectStore = useMultiSelectStore();
 </script>

--- a/apps/web/src/features/menu/ScrollButton.vue
+++ b/apps/web/src/features/menu/ScrollButton.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { scrollToCurrentTime } from "../../shared/lib";
-import { useEventListStore } from "../../store/eventListStore";
+import { useEventListStore } from "../streams";
 
 const eventListStore = useEventListStore();
 </script>

--- a/apps/web/src/features/menu/ScrollButton.vue
+++ b/apps/web/src/features/menu/ScrollButton.vue
@@ -3,7 +3,7 @@
 </doc>
 
 <script setup lang="ts">
-import { scrollToCurrentTime } from "../../shared/lib/scroll";
+import { scrollToCurrentTime } from "../../shared/lib";
 import { useEventListStore } from "../../store/eventListStore";
 
 const eventListStore = useEventListStore();

--- a/apps/web/src/features/menu/index.ts
+++ b/apps/web/src/features/menu/index.ts
@@ -1,0 +1,2 @@
+export { default as FooterMenu } from "./FooterMenu.vue";
+export { default as HeaderMenu } from "./HeaderMenu.vue";

--- a/apps/web/src/features/newArrivals/NewArrivalsButton.vue
+++ b/apps/web/src/features/newArrivals/NewArrivalsButton.vue
@@ -5,10 +5,10 @@
 <script setup lang="ts">
 import { computed, ref } from "vue";
 import { usePopover } from "../../shared/composables";
-import { useEventListStore } from "../../store/eventListStore";
 import NewArrivalsPopover from "./NewArrivalsPopover.vue";
+import { useNewArrivalsStore } from "./newArrivalsStore";
 
-const eventListStore = useEventListStore();
+const newArrivalsStore = useNewArrivalsStore();
 
 const lastCloseTime = ref(0);
 const popover = usePopover({
@@ -18,7 +18,8 @@ const popover = usePopover({
 });
 
 const unreadCount = computed(
-  () => eventListStore.addedEventList.filter((item) => item.addedTime > lastCloseTime.value).length,
+  () =>
+    newArrivalsStore.newArrivalsList.filter((item) => item.addedTime > lastCloseTime.value).length,
 );
 </script>
 

--- a/apps/web/src/features/newArrivals/NewArrivalsButton.vue
+++ b/apps/web/src/features/newArrivals/NewArrivalsButton.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
-import { usePopover } from "../../shared/composables/usePopover";
+import { usePopover } from "../../shared/composables";
 import { useEventListStore } from "../../store/eventListStore";
 import NewArrivalsPopover from "./NewArrivalsPopover.vue";
 

--- a/apps/web/src/features/newArrivals/NewArrivalsListItem.vue
+++ b/apps/web/src/features/newArrivals/NewArrivalsListItem.vue
@@ -6,9 +6,8 @@
 import type { LiverEvent } from "@liver-streams/core";
 import { compareDate, getDateTime, hhmmDateFormatter, toRelativeTime } from "@liver-streams/core";
 import { computed } from "vue";
-import { scrollToLiverEventTop } from "../../shared/lib/scroll";
-import { useDateStore } from "../../shared/stores/dateStore";
-import { useHoverStore } from "../../shared/stores/hoverStore";
+import { scrollToLiverEventTop } from "../../shared/lib";
+import { useDateStore, useHoverStore } from "../../shared/stores";
 
 const props = defineProps<{
   liverEvent: LiverEvent;

--- a/apps/web/src/features/newArrivals/NewArrivalsPopover.vue
+++ b/apps/web/src/features/newArrivals/NewArrivalsPopover.vue
@@ -5,15 +5,15 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { closePopover } from "../../shared/utils";
-import { useEventListStore } from "../../store/eventListStore";
 import NewArrivalsListItem from "./NewArrivalsListItem.vue";
+import { useNewArrivalsStore } from "./newArrivalsStore";
 
 defineProps<{
   lastCloseTime: number;
 }>();
 
-const eventListStore = useEventListStore();
-const eventCount = computed(() => eventListStore.addedEventList.length);
+const newArrivalsStore = useNewArrivalsStore();
+const eventCount = computed(() => newArrivalsStore.newArrivalsList.length);
 </script>
 
 <template>
@@ -39,7 +39,7 @@ const eventCount = computed(() => eventListStore.addedEventList.length);
       <!-- 逆順表示 -->
       <div v-else class="flex flex-col-reverse">
         <NewArrivalsListItem
-          v-for="{ liverEvent, addedTime } in eventListStore.addedEventList"
+          v-for="{ liverEvent, addedTime } in newArrivalsStore.newArrivalsList"
           :key="liverEvent.id"
           :addedTime="addedTime"
           :lastCloseTime="lastCloseTime"

--- a/apps/web/src/features/newArrivals/NewArrivalsPopover.vue
+++ b/apps/web/src/features/newArrivals/NewArrivalsPopover.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import { computed } from "vue";
-import { closePopover } from "../../shared/utils/popover";
+import { closePopover } from "../../shared/utils";
 import { useEventListStore } from "../../store/eventListStore";
 import NewArrivalsListItem from "./NewArrivalsListItem.vue";
 

--- a/apps/web/src/features/newArrivals/index.ts
+++ b/apps/web/src/features/newArrivals/index.ts
@@ -1,0 +1,3 @@
+export { default as NewArrivalsButton } from "./NewArrivalsButton.vue";
+export { useNewArrivalsStore } from "./newArrivalsStore";
+export type { NewArrival } from "./newArrivalsStore";

--- a/apps/web/src/features/newArrivals/index.ts
+++ b/apps/web/src/features/newArrivals/index.ts
@@ -1,3 +1,2 @@
 export { default as NewArrivalsButton } from "./NewArrivalsButton.vue";
 export { useNewArrivalsStore } from "./newArrivalsStore";
-export type { NewArrival } from "./newArrivalsStore";

--- a/apps/web/src/features/newArrivals/newArrivalsStore.ts
+++ b/apps/web/src/features/newArrivals/newArrivalsStore.ts
@@ -9,7 +9,7 @@ interface NewArrivalId {
   addedTime: number;
 }
 
-export interface NewArrival {
+interface NewArrival {
   addedTime: number;
   liverEvent: LiverEvent;
 }

--- a/apps/web/src/features/newArrivals/newArrivalsStore.ts
+++ b/apps/web/src/features/newArrivals/newArrivalsStore.ts
@@ -2,7 +2,7 @@ import type { LiverEvent } from "@liver-streams/core";
 import { talentFilter } from "@liver-streams/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { useTalentFilterStore } from "../channelFilter/talentFilterStore";
+import { useTalentFilterStore } from "../channelFilter";
 
 interface NewArrivalId {
   id: string;

--- a/apps/web/src/features/search/SearchFilter.vue
+++ b/apps/web/src/features/search/SearchFilter.vue
@@ -6,7 +6,7 @@
 
 <script setup lang="ts">
 import { ref, watch } from "vue";
-import { useSearchStore } from "../../shared/stores/searchStore";
+import { useSearchStore } from "../../shared/stores";
 
 const searchStore = useSearchStore();
 const inputEl = ref<HTMLInputElement | null>(null);

--- a/apps/web/src/features/search/index.ts
+++ b/apps/web/src/features/search/index.ts
@@ -1,0 +1,1 @@
+export { default as SearchFilter } from "./SearchFilter.vue";

--- a/apps/web/src/features/streams/LiverEventCard.vue
+++ b/apps/web/src/features/streams/LiverEventCard.vue
@@ -20,9 +20,7 @@ import { getThumbnail, hhss } from "@liver-streams/core";
 import type { LiverEvent } from "@liver-streams/core";
 import { computed, toRaw, toRefs } from "vue";
 import { getAffiliationLogo } from "../../shared/services";
-import { useHoverStore } from "../../shared/stores/hoverStore";
-import { useMultiSelectStore } from "../../shared/stores/multiSelectStore";
-import { useSearchStore } from "../../shared/stores/searchStore";
+import { useHoverStore, useMultiSelectStore, useSearchStore } from "../../shared/stores";
 import { useLiverEvent } from "./useLiverEvent";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/LiverEventDateSection.vue
+++ b/apps/web/src/features/streams/LiverEventDateSection.vue
@@ -8,8 +8,8 @@
 import type { DateSection } from "@liver-streams/core";
 import { compareDate, mdDateFormatter, relativeDateFormatter } from "@liver-streams/core";
 import { computed } from "vue";
-import { scrollToSectionTop } from "../../shared/lib/scroll";
-import { useDateStore } from "../../shared/stores/dateStore";
+import { scrollToSectionTop } from "../../shared/lib";
+import { useDateStore } from "../../shared/stores";
 import LiverEventTimeSection from "./LiverEventTimeSection.vue";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/LiverEventDateSectionList.vue
+++ b/apps/web/src/features/streams/LiverEventDateSectionList.vue
@@ -8,8 +8,8 @@
 import type { DateSection } from "@liver-streams/core";
 import { nextTick, onMounted, watch } from "vue";
 import { scrollToCurrentTime } from "../../shared/lib";
-import { useEventListStore } from "../../store/eventListStore";
 import { LoadingSpinner } from "../common";
+import { useEventListStore } from "./eventListStore";
 import LiverEventDateSection from "./LiverEventDateSection.vue";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/LiverEventDateSectionList.vue
+++ b/apps/web/src/features/streams/LiverEventDateSectionList.vue
@@ -7,9 +7,9 @@
 <script setup lang="ts">
 import type { DateSection } from "@liver-streams/core";
 import { nextTick, onMounted, watch } from "vue";
-import { scrollToCurrentTime } from "../../shared/lib/scroll";
+import { scrollToCurrentTime } from "../../shared/lib";
 import { useEventListStore } from "../../store/eventListStore";
-import LoadingSpinner from "../common/LoadingSpinner.vue";
+import { LoadingSpinner } from "../common";
 import LiverEventDateSection from "./LiverEventDateSection.vue";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/LiverEventTimeSection.vue
+++ b/apps/web/src/features/streams/LiverEventTimeSection.vue
@@ -8,7 +8,7 @@
 import type { TimeSection } from "@liver-streams/core";
 import { hhmmDateFormatter } from "@liver-streams/core";
 import { computed, ref } from "vue";
-import { useDateStore } from "../../shared/stores/dateStore";
+import { useDateStore } from "../../shared/stores";
 import LiverEventCard from "./LiverEventCard.vue";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/detail/LiverEventDetailList.vue
+++ b/apps/web/src/features/streams/detail/LiverEventDetailList.vue
@@ -5,7 +5,7 @@
 </doc>
 
 <script setup lang="ts">
-import { useEventListStore } from "../../../store/eventListStore";
+import { useEventListStore } from "../eventListStore";
 import LiverEventDetailListItem from "./LiverEventDetailListItem.vue";
 
 const eventListStore = useEventListStore();

--- a/apps/web/src/features/streams/detail/LiverEventDetailListItem.vue
+++ b/apps/web/src/features/streams/detail/LiverEventDetailListItem.vue
@@ -4,7 +4,7 @@
 
 <script setup lang="ts">
 import type { LiverEvent } from "@liver-streams/core";
-import { usePopover } from "../../../shared/composables/usePopover";
+import { usePopover } from "../../../shared/composables";
 import LiverEventDetailPopover from "./LiverEventDetailPopover.vue";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/detail/LiverEventDetailPopover.vue
+++ b/apps/web/src/features/streams/detail/LiverEventDetailPopover.vue
@@ -14,12 +14,10 @@
 import type { LiverEvent } from "@liver-streams/core";
 import { parseSegment, getThumbnail, fullDateFormatter } from "@liver-streams/core";
 import { computed, toRef } from "vue";
-import { useBookmarkStore } from "../../../features/bookmark/bookmarkStore";
-import { useNotificationStore } from "../../../features/bookmark/notificationStore";
-import { usePopover } from "../../../shared/composables/usePopover";
-import { useHoverStore } from "../../../shared/stores/hoverStore";
-import { useSearchStore } from "../../../shared/stores/searchStore";
-import { closePopover } from "../../../shared/utils/popover";
+import { usePopover } from "../../../shared/composables";
+import { useHoverStore, useSearchStore } from "../../../shared/stores";
+import { closePopover } from "../../../shared/utils";
+import { useBookmarkStore, useNotificationStore } from "../../bookmark";
 import { useLiverEvent } from "../useLiverEvent";
 
 const props = defineProps<{

--- a/apps/web/src/features/streams/eventListStore.ts
+++ b/apps/web/src/features/streams/eventListStore.ts
@@ -2,11 +2,11 @@ import { getFilteredEventList, createDateSectionList } from "@liver-streams/core
 import type { LiverEvent } from "@liver-streams/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { processBookmarkNotification } from "../features/bookmark";
-import { useTalentFilterStore } from "../features/channelFilter";
-import { useNewArrivalsStore } from "../features/newArrivals";
-import { fetchAllEvents } from "../shared/services";
-import { useSearchStore } from "../shared/stores";
+import { fetchAllEvents } from "../../shared/services";
+import { useSearchStore } from "../../shared/stores";
+import { processBookmarkNotification } from "../bookmark";
+import { useTalentFilterStore } from "../channelFilter";
+import { useNewArrivalsStore } from "../newArrivals";
 
 export const useEventListStore = defineStore("eventListStore", () => {
   const talentFilterStore = useTalentFilterStore();
@@ -29,7 +29,6 @@ export const useEventListStore = defineStore("eventListStore", () => {
     return filteredEventList.value.filter((event) => event.isLive);
   });
 
-  // ローディング状態（初回データ取得前）
   const isLoading = computed(() => liverEventList.value === null);
 
   const dateSectionList = computed(() => {
@@ -39,29 +38,20 @@ export const useEventListStore = defineStore("eventListStore", () => {
   });
 
   async function updateLiverEventList() {
-    // list取得
     const newLiverEventList = await fetchAllEvents();
 
-    // map更新
     const eventMap = new Map<string, LiverEvent>();
     newLiverEventList.forEach((liverEvent) => {
       eventMap.set(liverEvent.id, liverEvent);
     });
     liverEventMap.value = eventMap;
 
-    // 新着更新
     newArrivalsStore.updateNewArrivals(newLiverEventList, liverEventList.value, eventMap);
 
-    // list更新
     liverEventList.value = newLiverEventList;
 
-    // bookmark通知処理
     processBookmarkNotification(eventMap);
   }
-
-  // 後方互換性のためのエイリアス
-  const addedEventList = computed(() => newArrivalsStore.newArrivalsList);
-  const addedEventIdSet = computed(() => newArrivalsStore.newArrivalsIdSet);
 
   return {
     liverEventList,
@@ -69,11 +59,8 @@ export const useEventListStore = defineStore("eventListStore", () => {
     onLiveEventList,
     dateSectionList,
     liverEventMap,
-    addedEventList,
-    addedEventIdSet,
     isLoading,
     updateLiverEventList,
-    clearAddedEventList: () => newArrivalsStore.clearNewArrivals(),
   };
 });
 

--- a/apps/web/src/features/streams/index.ts
+++ b/apps/web/src/features/streams/index.ts
@@ -1,2 +1,3 @@
+export { useEventListStore } from "./eventListStore";
 export { default as LiverEventDateSectionList } from "./LiverEventDateSectionList.vue";
 export { default as LiverEventDetailList } from "./detail/LiverEventDetailList.vue";

--- a/apps/web/src/features/streams/index.ts
+++ b/apps/web/src/features/streams/index.ts
@@ -1,0 +1,2 @@
+export { default as LiverEventDateSectionList } from "./LiverEventDateSectionList.vue";
+export { default as LiverEventDetailList } from "./detail/LiverEventDetailList.vue";

--- a/apps/web/src/features/streams/useLiverEvent.ts
+++ b/apps/web/src/features/streams/useLiverEvent.ts
@@ -1,9 +1,8 @@
 import type { LiverEvent } from "@liver-streams/core";
 import { computed, toRaw, type Ref } from "vue";
-import { useBookmarkStore } from "../../features/bookmark/bookmarkStore";
-import { useDateStore } from "../../shared/stores/dateStore";
-import { useHoverStore } from "../../shared/stores/hoverStore";
+import { useDateStore, useHoverStore } from "../../shared/stores";
 import { useEventListStore } from "../../store/eventListStore";
+import { useBookmarkStore } from "../bookmark";
 
 const oneHour = 60 * 60 * 1000;
 

--- a/apps/web/src/features/streams/useLiverEvent.ts
+++ b/apps/web/src/features/streams/useLiverEvent.ts
@@ -1,8 +1,8 @@
 import type { LiverEvent } from "@liver-streams/core";
 import { computed, toRaw, type Ref } from "vue";
 import { useDateStore, useHoverStore } from "../../shared/stores";
-import { useEventListStore } from "../../store/eventListStore";
 import { useBookmarkStore } from "../bookmark";
+import { useNewArrivalsStore } from "../newArrivals";
 
 const oneHour = 60 * 60 * 1000;
 
@@ -12,8 +12,8 @@ const liveEndDuration = 60 * 60 * 1000;
 
 export const useLiverEvent = (liverEvent: Ref<LiverEvent>) => {
   const dateStore = useDateStore();
-  const eventListStore = useEventListStore();
   const bookmarkStore = useBookmarkStore();
+  const newArrivalsStore = useNewArrivalsStore();
   const hoverStore = useHoverStore();
 
   // 配信終了判定
@@ -84,7 +84,7 @@ export const useLiverEvent = (liverEvent: Ref<LiverEvent>) => {
   });
 
   const isNew = computed(() => {
-    return eventListStore.addedEventIdSet.has(liverEvent.value.id);
+    return newArrivalsStore.newArrivalsIdSet.has(liverEvent.value.id);
   });
 
   const hasBookmark = computed(() => {

--- a/apps/web/src/shared/composables/index.ts
+++ b/apps/web/src/shared/composables/index.ts
@@ -1,0 +1,1 @@
+export { usePopover } from "./usePopover";

--- a/apps/web/src/shared/lib/index.ts
+++ b/apps/web/src/shared/lib/index.ts
@@ -1,0 +1,1 @@
+export { scrollToCurrentTime, scrollToLiverEventTop, scrollToSectionTop } from "./scroll";

--- a/apps/web/src/shared/lib/scroll.test.ts
+++ b/apps/web/src/shared/lib/scroll.test.ts
@@ -1,6 +1,6 @@
+import type { DateSection } from "@liver-streams/core";
 import { describe, it, expect, spyOn, mock } from "bun:test";
-import type { DateSection } from "./section";
-import { scrollToCurrentTime } from "./";
+import { scrollToCurrentTime } from "./scroll";
 
 function createDateSection(times: [number, ...number[]]): DateSection {
   const firstTime = times[0];

--- a/apps/web/src/shared/lib/scroll.test.ts
+++ b/apps/web/src/shared/lib/scroll.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, spyOn, mock } from "bun:test";
-import { scrollToCurrentTime } from "./scroll";
 import type { DateSection } from "./section";
+import { scrollToCurrentTime } from "./";
 
 function createDateSection(times: [number, ...number[]]): DateSection {
   const firstTime = times[0];

--- a/apps/web/src/shared/services/index.ts
+++ b/apps/web/src/shared/services/index.ts
@@ -29,4 +29,3 @@ export function getAffiliationLogo(affiliation: string): string {
 }
 
 // Re-export types
-export type { LiverEvent } from "@liver-streams/core";

--- a/apps/web/src/shared/stores/index.ts
+++ b/apps/web/src/shared/stores/index.ts
@@ -1,0 +1,5 @@
+export { useDateStore } from "./dateStore";
+export { useHoverStore } from "./hoverStore";
+export { useMultiSelectStore } from "./multiSelectStore";
+export { useScrollStore } from "./scrollStore";
+export { useSearchStore } from "./searchStore";

--- a/apps/web/src/shared/stores/searchStore.ts
+++ b/apps/web/src/shared/stores/searchStore.ts
@@ -1,7 +1,7 @@
 import { parseSearchString, searchQueryToSearchString } from "@liver-streams/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { useScrollStore } from "./scrollStore";
+import { useScrollStore } from "./";
 
 export const useSearchStore = defineStore("searchStore", () => {
   const scrollStore = useScrollStore();

--- a/apps/web/src/shared/utils/index.ts
+++ b/apps/web/src/shared/utils/index.ts
@@ -1,0 +1,1 @@
+export { closePopover } from "./popover";

--- a/apps/web/src/store/eventListStore.ts
+++ b/apps/web/src/store/eventListStore.ts
@@ -2,11 +2,11 @@ import { getFilteredEventList, createDateSectionList } from "@liver-streams/core
 import type { LiverEvent } from "@liver-streams/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed, ref } from "vue";
-import { processBookmarkNotification } from "../features/bookmark/useBookmarkNotification";
-import { useTalentFilterStore } from "../features/channelFilter/talentFilterStore";
-import { useNewArrivalsStore } from "../features/newArrivals/newArrivalsStore";
+import { processBookmarkNotification } from "../features/bookmark";
+import { useTalentFilterStore } from "../features/channelFilter";
+import { useNewArrivalsStore } from "../features/newArrivals";
 import { fetchAllEvents } from "../shared/services";
-import { useSearchStore } from "../shared/stores/searchStore";
+import { useSearchStore } from "../shared/stores";
 
 export const useEventListStore = defineStore("eventListStore", () => {
   const talentFilterStore = useTalentFilterStore();

--- a/apps/web/src/views/LiverStreamsView.vue
+++ b/apps/web/src/views/LiverStreamsView.vue
@@ -11,10 +11,8 @@
 <script setup lang="ts">
 import { useIntervalFn } from "@vueuse/core";
 import { onMounted } from "vue";
-import FooterMenu from "../features/menu/FooterMenu.vue";
-import HeaderMenu from "../features/menu/HeaderMenu.vue";
-import LiverEventDetailList from "../features/streams/detail/LiverEventDetailList.vue";
-import LiverEventDateSectionList from "../features/streams/LiverEventDateSectionList.vue";
+import { FooterMenu, HeaderMenu } from "../features/menu";
+import { LiverEventDateSectionList, LiverEventDetailList } from "../features/streams";
 import { useEventListStore } from "../store/eventListStore";
 
 const fetchInterval = 1 * 60 * 1000; // 1min

--- a/apps/web/src/views/LiverStreamsView.vue
+++ b/apps/web/src/views/LiverStreamsView.vue
@@ -12,8 +12,11 @@
 import { useIntervalFn } from "@vueuse/core";
 import { onMounted } from "vue";
 import { FooterMenu, HeaderMenu } from "../features/menu";
-import { LiverEventDateSectionList, LiverEventDetailList } from "../features/streams";
-import { useEventListStore } from "../store/eventListStore";
+import {
+  LiverEventDateSectionList,
+  LiverEventDetailList,
+  useEventListStore,
+} from "../features/streams";
 
 const fetchInterval = 1 * 60 * 1000; // 1min
 const eventListStore = useEventListStore();

--- a/knip.ts
+++ b/knip.ts
@@ -1,0 +1,38 @@
+import type { KnipConfig } from "knip";
+
+const config: KnipConfig = {
+  workspaces: {
+    "packages/core": {
+      project: ["src/**/*.ts"],
+    },
+    "packages/hololive": {
+      entry: ["scripts/*.ts"],
+      project: ["src/**/*.ts", "scripts/**/*.ts"],
+    },
+    "packages/nijisanji": {
+      entry: ["scripts/*.ts"],
+      project: ["src/**/*.ts", "scripts/**/*.ts"],
+    },
+    "apps/web": {
+      project: ["src/**/*.{ts,vue}"],
+
+      ignoreDependencies: [
+        // CSS で使用（knip は CSS の @plugin を解析できない）
+        "@egoist/tailwindcss-icons",
+        "@iconify-json/eva",
+        "@iconify-json/icon-park-outline",
+        "@iconify-json/icon-park-solid",
+        "@iconify-json/mdi",
+        // bunfig.toml preload で使用（knip は bun preload を解析できない）
+        "@happy-dom/global-registrator",
+        "happy-dom",
+      ],
+
+      eslint: {
+        config: ["eslint.config.ts", "eslint.config.fix.ts", "eslint.base.ts"],
+      },
+    },
+  },
+};
+
+export default config;

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -21,24 +21,46 @@ pre-commit:
         - "packages/**"
       run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
       stage_fixed: true
-    - name: oxlint-core
+    # packages/core: fix: oxlint + oxfmt → knip
+    - name: core
       root: "packages/core/"
       glob: "**/*.ts"
-      run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
-      stage_fixed: true
-    - name: oxlint-hololive
+      group:
+        piped: true
+        jobs:
+          - name: oxlint
+            run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
+            stage_fixed: true
+          - name: knip
+            run: pnpm -w run knip -W packages/core --fix
+
+    # packages/hololive: fix: oxlint + oxfmt → knip
+    - name: hololive
       root: "packages/hololive/"
       glob: "**/*.ts"
-      run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
-      stage_fixed: true
-    - name: oxlint-nijisanji
+      group:
+        piped: true
+        jobs:
+          - name: oxlint
+            run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
+            stage_fixed: true
+          - name: knip
+            run: pnpm -w run knip -W packages/hololive --fix
+
+    # packages/nijisanji: fix: oxlint + oxfmt → knip
+    - name: nijisanji
       root: "packages/nijisanji/"
       glob: "**/*.ts"
-      run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
-      stage_fixed: true
+      group:
+        piped: true
+        jobs:
+          - name: oxlint
+            run: pnpm exec oxlint --type-aware --fix {staged_files} && pnpm exec oxfmt {staged_files}
+            stage_fixed: true
+          - name: knip
+            run: pnpm -w run knip -W packages/nijisanji --fix
 
-    # apps/web: .ts は oxlint、.vue は eslint。oxfmt は全ファイルに適用
-    # 同一ファイルへの競合を避けるため piped で直列実行
+    # apps/web: fix: oxlint + eslint + oxfmt → knip（fix 完了後の状態で解析するため piped で直列実行）
     - name: web
       root: apps/web/
       glob: "**/*.{ts,vue,css,scss,md}"
@@ -56,6 +78,9 @@ pre-commit:
           - name: oxfmt
             run: pnpm exec oxfmt {staged_files}
             stage_fixed: true
+          - name: knip
+            glob: "**/*.{ts,vue}"
+            run: pnpm -w run knip -W apps/web --fix
 
 # git pull / merge 後に lockfile の変更を検出し、pnpm install を促す
 post-merge:

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "lint:all": "pnpm -r --include-workspace-root --no-bail --aggregate-output --reporter=append-only lint",
     "fix": "oxfmt '!apps/**' '!packages/**'",
     "fix:all": "pnpm -r --include-workspace-root --no-bail --aggregate-output --reporter=append-only fix",
+    "knip": "knip",
     "prepare": "lefthook install"
   },
   "devDependencies": {
@@ -20,6 +21,7 @@
     "@tsconfig/node24": "catalog:",
     "@types/node": "catalog:",
     "@typescript/native-preview": "catalog:",
+    "knip": "^6.6.1",
     "lefthook": "2.1.6",
     "oxfmt": "catalog:",
     "oxlint": "catalog:",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -123,6 +123,9 @@ importers:
       '@iconify-json/mdi':
         specifier: 1.2.3
         version: 1.2.3
+      '@miyaoka/eslint-plugin-barrel-import':
+        specifier: ^0.0.0
+        version: 0.0.0(eslint@10.2.1(jiti@2.6.1))
       '@miyaoka/vite-plugin-doc-block':
         specifier: 0.0.2
         version: 0.0.2(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))
@@ -537,6 +540,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@miyaoka/eslint-plugin-barrel-import@0.0.0':
+    resolution: {integrity: sha512-j8uDx/SCXcplFzCyYAy9jhy/zgXYE9CHIm4XC22FmdEpF4DctebObC9+1l000QfFaSnTr7PFPkJjxHLzZXKn4Q==}
+    peerDependencies:
+      eslint: '>=9'
 
   '@miyaoka/vite-plugin-doc-block@0.0.2':
     resolution: {integrity: sha512-YRw8jgPIo1RyXNN4GY1lGOSrzillJzbor5gm2FT//cy3Xher069HoaZS7IMN9r2trpzfY3PkE14wEw9s/CGx+A==}
@@ -2954,6 +2962,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@miyaoka/eslint-plugin-barrel-import@0.0.0(eslint@10.2.1(jiti@2.6.1))':
+    dependencies:
+      eslint: 10.2.1(jiti@2.6.1)
 
   '@miyaoka/vite-plugin-doc-block@0.0.2(vite@8.0.10(@types/node@24.12.2)(jiti@2.6.1)(yaml@2.8.3))(vue@3.5.33(typescript@6.0.3))':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@typescript/native-preview':
         specifier: 'catalog:'
         version: 7.0.0-dev.20260423.1
+      knip:
+        specifier: ^6.6.1
+        version: 6.6.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
       lefthook:
         specifier: 2.1.6
         version: 2.1.6
@@ -447,8 +450,14 @@ packages:
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
 
+  '@emnapi/core@1.9.2':
+    resolution: {integrity: sha512-UC+ZhH3XtczQYfOlu3lNEkdW/p4dsJ1r/bP7H8+rhao3TTTMO1ATq/4DdIi23XuGoFY+Cz0JmCbdVl0hz9jZcA==}
+
   '@emnapi/runtime@1.10.0':
     resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@emnapi/runtime@1.9.2':
+    resolution: {integrity: sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==}
 
   '@emnapi/wasi-threads@1.2.1':
     resolution: {integrity: sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==}
@@ -573,8 +582,246 @@ packages:
     resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
     engines: {node: '>= 8'}
 
+  '@oxc-parser/binding-android-arm-eabi@0.126.0':
+    resolution: {integrity: sha512-svyoHt25J4741QJ5aa4R+h0iiBeSRt63Lr3aAZcxy2c/NeSE1IfDeMnSij6rIg7EjxkdlXzz613wUjeCeilBNA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.126.0':
+    resolution: {integrity: sha512-hPEBRKgplp1mG9GkINFsr4JVMDNrGJLOqfDaadTWpAoTnzYR5Rmv8RMvB3hJZpiNvbk1aacopdHUP1pggMQ/cw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.126.0':
+    resolution: {integrity: sha512-ccRpu9sdYmznePJQG5halhs0FW5tw5a8zRSoZXOzM1OjoeZ4jiRRruFiPclsD59edoVAK1l83dvfjWz1nQi6lg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.126.0':
+    resolution: {integrity: sha512-CHB4zVjNSKqx8Fw9pHowzQQnjjuq04i4Ng0Avj+DixlwhwAoMYqlFbocYIlbg+q3zOLGlm7vEHm83jqEMitnyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.126.0':
+    resolution: {integrity: sha512-RQ3nEJdcDKBfBjmLJ3Vl1d0KQERPV1P8eUrnBm7+VTYyoaJSPLVFuPg1mlD1hk3n0/879VLFMfusFkBal4ssWQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.126.0':
+    resolution: {integrity: sha512-onipc2wCDA7Bauzb4KK1mab0GsEDf4ujiIfWECdnmY/2LlzAoX3xdQRLAUyEDB1kn3yilHBrkmXDdHluyHXxiw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.126.0':
+    resolution: {integrity: sha512-5BuJJPohrV5NJ8lmcYOMbfRCUGoYH5J9HZHeuqOLwkHXWAuPMN3X1h8bC/2mWjmosdbfTtmyIdX3spS/TkqKNg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.126.0':
+    resolution: {integrity: sha512-r2KApRgm2pOJaduRm6GOT8x0whcr67AyejNkSdzPt34GJ+Y3axcXN2mwlTs+8lfO/SSmpO5ZJGYiHYnxEE0jkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.126.0':
+    resolution: {integrity: sha512-FQ+MMh7MT0Dr/u8+RWmWKlfoeWPQyHDbhhxJShJlYtROXXPHsRs9EvmQOZZ3sx4Nn7JU8NX+oyw2YzQ7anBJcA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.126.0':
+    resolution: {integrity: sha512-Wv/T8C98hRQhGTlx2XFyLn5raRMp9U1lOQD+YnXNgAr7wHbJJpZ8mDBU7Rw+M3WytGcGTFcr6kqgfyQeHVtLbQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.126.0':
+    resolution: {integrity: sha512-DHx1rT1zauW0ZbLHOiQh5AC9Xs3UkWx2XmfZHs+7nnWYr3sagrufoUQC+/XPwwjMIlCFXiFGM0sFh3TyOCZwqA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.126.0':
+    resolution: {integrity: sha512-umDc2mTShH0U2zcEYf8mIJ163seLJNn54ZUZYeI5jD4qlg9izPwoLrC2aNPKlMJTu6u/ysmQWiEvIiaAG+INkw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.126.0':
+    resolution: {integrity: sha512-PXXeWayclRtO1pxQEeCpiqIglQdhK2mAI2VX5xnsWdImzSB5GpoQ8TNw7vTCKk2k+GZuxl+q1knncidjCyUP9w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.126.0':
+    resolution: {integrity: sha512-wzocjxm34TbB3bFlqG65JiLtvf6ZDg2ZxRkLLbgXwDQUNU+0MPjQN8zy/0jBKNA5fnPLk3XeVdZ7Uin+7+CVkg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-parser/binding-linux-x64-musl@0.126.0':
+    resolution: {integrity: sha512-e83uftP60jmkPs2+CW6T6A1GYzN2H6IumDAiTntv9WyHR73PI3ImHNBkYqnA3ukeKI3xjcCbhSh9QeJWmufxGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-parser/binding-openharmony-arm64@0.126.0':
+    resolution: {integrity: sha512-4WiOILHnPrTDY2/L4mE6PZCYwLN1d3ghma6BuTJ452CCgzRMt3uFplCtR+o3r9zdUWJYb370UizpI9CUcWXr1A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.126.0':
+    resolution: {integrity: sha512-Y17hhnrQTrxgAxAyAq401vnN9URsAL4s5AjqpG1NDsXSlhe1yBNnns+rC2P6xcMoitgX5nKH2ryYt9oiFRlzLw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.126.0':
+    resolution: {integrity: sha512-Znug1u1iRvT4VC3jANz6nhGBHsFwEFMxuimYpJFwMtsB6H5FcEoZRMmH26tHkSTD03JvDmG+gB65W3ajLjPcSw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.126.0':
+    resolution: {integrity: sha512-qrw7mx5hFFTxVSXToOA40hpnjgNB/DJprZchtB4rDKNLKqkD3F26HbzaQeH1nxAKej0efSZfJd5Sw3qdtOLGhw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.126.0':
+    resolution: {integrity: sha512-ibB1s+mPUFXvS7MFJO2jpw/aCNs/P6ifnWlRyTYB+WYBpniOiCcHQQskZneJtwcjQMDRol3RGG3ihoYnzXSY4w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.126.0':
+    resolution: {integrity: sha512-oGfVtjAgwQVVpfBrbtk4e1XDyWHRFta6BS3GWVzrF8xYBT2VGQAk39yJS/wFSMrZqoiCU4oghT3Ch0HaHGIHcQ==}
+
   '@oxc-project/types@0.127.0':
     resolution: {integrity: sha512-aIYXQBo4lCbO4z0R3FHeucQHpF46l2LbMdxRvqvuRuW2OxdnSkcng5B8+K12spgLDj93rtN3+J2Vac/TIO+ciQ==}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    resolution: {integrity: sha512-aUs47y+xyXHUKlbhqHUjBABjvycq6YSD7bpxSW7vplUmdzAlJ93yXY6ZR0c1o1x5A/QKbENCvs3+NlY8IpIVzg==}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    resolution: {integrity: sha512-oolbkRX+m7Pq2LNjr/kKgYeC7bRDMVTWPgxBGMjSpZi/+UskVo4jsMU3MLheZV55jL6c3rNelPl4oD60ggYmqA==}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    resolution: {integrity: sha512-nUC6d2i3R5B12sUW4O646qD5cnMXf2oBGPLIIeaRfU9doJRORAbE2SGv4eW6rMqhD+G7nf2Y8TTJTLiiO3Q/dQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    resolution: {integrity: sha512-cV50vE5+uAgNcFa3QY1JOeKDSkM/9ReIcc/9wn4TavhW/itkDGrXhw9jaKnkQnGbjJ198Yh5nbX/Gr2mr4Z5jQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    resolution: {integrity: sha512-xZOQiYGFxtk48PBKff+Zwoym7ScPAIVp4c14lfLxizO2LTTTJe5sx9vQNGrBymrf/vatSPNMD4FgsaaRigPkqw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    resolution: {integrity: sha512-lXZYWAC6kaGe/ky2su94e9jN9t6M0/6c+GrSlCqL//XO1cxi5lpAhnJYdyrKfm0ZEr/c7RNyAx3P7FSBcBd5+A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    resolution: {integrity: sha512-veG1kKsuK5+t2IsO9q0DErYVSw2azvCVvWHnfTOS73WE0STdLLB7Q1bB9WR+yHPQM76ASkFyRbogWo1GR1+WbQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
+    resolution: {integrity: sha512-heV2+jmXyYnUrpUXSPugqWDRpnsQcDm2AX4wzTuvgdlZfoNYO0O3W2AVpJYaDn9AG4JdM6Kxom8+foE7/BcSig==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
+    resolution: {integrity: sha512-jvo2Pjs1c9KPxMuMPIeQsgu0mOJF9rEb3y3TdpsrqwxRM+AN6/nDDwv45n5ZrUnQMsdBy5gIabioMKnQfWo9ew==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    resolution: {integrity: sha512-vLmdNxWCdN7Uo5suays6A/+ywBby2PWBBPXctWPg5V0+eVuzsJxgAn6MMB4mPlshskYbppjpN2Zg83ArHze9gQ==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    resolution: {integrity: sha512-/b+WgR+VTSBxzgOhDO7TlMXC1ufPIMR6Vj1zN+/x+MnyXGW7prTLzU9eW85Aj7Th7CCEG9ArCbTeqxCzFWdg2w==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    resolution: {integrity: sha512-YlRdeWb9j42p29ROh+h4eg/OQ3dTJlpHSa+84pUM9+p6i3djtPz1q55yLJhgW9XfDch7FN1pQ/Vd6YP+xfRIuw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    resolution: {integrity: sha512-EDpafVOQWF8/MJynsjOGFThcqhRHy417sRyLfQmeiamJ8qVhSKAn2Dn2VVKUGCjVB9C46VGjhNo7nOPUi1x6uA==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
+    resolution: {integrity: sha512-NxjZe+rqWhr+RT8/Ik+5ptA3oz7tUw361Wa5RWQXKnfqwSSHdHyrw6IdcTfYuml9dM856AlKWZIUXDmA9kkiBQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@oxc-resolver/binding-linux-x64-musl@11.19.1':
+    resolution: {integrity: sha512-cM/hQwsO3ReJg5kR+SpI69DMfvNCp+A/eVR4b4YClE5bVZwz8rh2Nh05InhwI5HR/9cArbEkzMjcKgTHS6UaNw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    resolution: {integrity: sha512-QF080IowFB0+9Rh6RcD19bdgh49BpQHUW5TajG1qvWHvmrQznTZZjYlgE2ltLXyKY+qs4F/v5xuX1XS7Is+3qA==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1':
+    resolution: {integrity: sha512-w8UCKhX826cP/ZLokXDS6+milN8y4X7zidsAttEdWlVoamTNf6lhBJldaWr3ukTDiye7s4HRcuPEPOXNC432Vg==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    resolution: {integrity: sha512-nJ4AsUVZrVKwnU/QRdzPCCrO0TrabBqgJ8pJhXITdZGYOV28TIYystV1VFLbQ7DtAcaBHpocT5/ZJnF78YJPtQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    resolution: {integrity: sha512-EW+ND5q2Tl+a3pH81l1QbfgbF3HmqgwLfDfVithRFheac8OTcnbXt/JxqD2GbDkb7xYEqy1zNaVFRr3oeG8npA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    resolution: {integrity: sha512-6hIU3RQu45B+VNTY4Ru8ppFwjVS/S5qwYyGhBotmjxfEKk41I2DlGtRfGJndZ5+6lneE2pwloqunlOyZuX/XAw==}
+    cpu: [x64]
+    os: [win32]
 
   '@oxfmt/binding-android-arm-eabi@0.46.0':
     resolution: {integrity: sha512-b1doV4WRcJU+BESSlCvCjV+5CEr/T6h0frArAdV26Nir+gGNFNaylvDiiMPfF1pxeV0txZEs38ojzJaxBYg+ng==}
@@ -1770,6 +2017,9 @@ packages:
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
+  fd-package-json@2.0.0:
+    resolution: {integrity: sha512-jKmm9YtsNXN789RS/0mSzOC1NUq9mkVd65vbSSVsKdjGvYXBuE4oWe2QOEoFeRmJg+lPuZxpmrfFclNhoRMneQ==}
+
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
     engines: {node: '>=12.0.0'}
@@ -1797,6 +2047,11 @@ packages:
 
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
+
+  formatly@0.3.0:
+    resolution: {integrity: sha512-9XNj/o4wrRFyhSMJOvsuyMwy8aUfBaZ1VrqHVfohyXf0Sw0e+yfKG+xZaY3arGCOMdwFsqObtzVOc1gU9KiT9w==}
+    engines: {node: '>=18.3.0'}
+    hasBin: true
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -1913,6 +2168,11 @@ packages:
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
+
+  knip@6.6.1:
+    resolution: {integrity: sha512-SOmqh25vuAfdynGoDr/kMCxIuD5+PkMIfMSGQeMqfrxwuPTANvJKcVttLgGZjjkATALqukSe/hhDVqcwNkf92g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
 
   kolorist@1.8.0:
     resolution: {integrity: sha512-Y+60/zizpJ3HRH8DCss+q95yr6145JXZo46OTpFvDZWLfRCE4qChOyk1b26nMaNpfHHgxagk9dXT5OP0Tfe+dQ==}
@@ -2144,6 +2404,13 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxc-parser@0.126.0:
+    resolution: {integrity: sha512-FktCvLby/mOHyuijZt22+nOt10dS24gGUZE3XwIbUg7Kf4+rer3/5T7RgwzazlNuVsCjPloZ3p8E+4ONT3A8Kw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  oxc-resolver@11.19.1:
+    resolution: {integrity: sha512-qE/CIg/spwrTBFt5aKmwe3ifeDdLfA2NESN30E42X/lII5ClF8V7Wt6WIJhcGZjp0/Q+nQ+9vgxGk//xZNX2hg==}
+
   oxfmt@0.46.0:
     resolution: {integrity: sha512-CopwJOwPAjZ9p76fCvz+mSOJTw9/NY3cSksZK3VO/bUQ8UoEcketNgUuYS0UB3p+R9XnXe7wGGXUmyFxc7QxJA==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -2314,6 +2581,10 @@ packages:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
+    engines: {node: '>= 18'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -2329,6 +2600,10 @@ packages:
   strip-bom@3.0.0:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
+
+  strip-json-comments@5.0.3:
+    resolution: {integrity: sha512-1tB5mhVo7U+ETBKNf92xT4hrQa3pm0MZ0PQvuDnWgAAGHDsfp4lPSpiS6psrSiet87wyGPh9ft6wmhOMQ0hDiw==}
+    engines: {node: '>=14.16'}
 
   superjson@2.2.6:
     resolution: {integrity: sha512-H+ue8Zo4vJmV2nRjpx86P35lzwDT3nItnIsocgumgr0hHMQ+ZGq5vrERg9kJBo5AWGmxZDhzDo+WVIJqkB0cGA==}
@@ -2413,6 +2688,10 @@ packages:
 
   ufo@1.6.3:
     resolution: {integrity: sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==}
+
+  unbash@2.2.0:
+    resolution: {integrity: sha512-X2wH19RAPZE3+ldGicOkoj/SIA83OIxcJ6Cuaw23hf8Xc6fQpvZXY0SftE2JgS0QhYLUG4uwodSI3R53keyh7w==}
+    engines: {node: '>=14'}
 
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
@@ -2594,6 +2873,10 @@ packages:
       typescript:
         optional: true
 
+  walk-up-path@4.0.0:
+    resolution: {integrity: sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A==}
+    engines: {node: 20 || >=22}
+
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
 
@@ -2646,6 +2929,9 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zod@4.3.6:
+    resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
 
 snapshots:
 
@@ -2856,7 +3142,18 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.2':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.1
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.9.2':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -2986,6 +3283,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
       '@nodelib/fs.stat': 2.0.5
@@ -2998,7 +3302,138 @@ snapshots:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.20.1
 
+  '@oxc-parser/binding-android-arm-eabi@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.126.0':
+    dependencies:
+      '@emnapi/core': 1.9.2
+      '@emnapi/runtime': 1.9.2
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.126.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.126.0':
+    optional: true
+
+  '@oxc-project/types@0.126.0': {}
+
   '@oxc-project/types@0.127.0': {}
+
+  '@oxc-resolver/binding-android-arm-eabi@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-android-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-darwin-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-freebsd-x64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-gnueabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm-musleabihf@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-arm64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-ppc64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-riscv64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-s390x-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-gnu@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-linux-x64-musl@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-openharmony-arm64@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-wasm32-wasi@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+    optional: true
+
+  '@oxc-resolver/binding-win32-arm64-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-ia32-msvc@11.19.1':
+    optional: true
+
+  '@oxc-resolver/binding-win32-x64-msvc@11.19.1':
+    optional: true
 
   '@oxfmt/binding-android-arm-eabi@0.46.0':
     optional: true
@@ -3995,6 +4430,10 @@ snapshots:
     dependencies:
       reusify: 1.1.0
 
+  fd-package-json@2.0.0:
+    dependencies:
+      walk-up-path: 4.0.0
+
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
       picomatch: 4.0.4
@@ -4018,6 +4457,10 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.4.2: {}
+
+  formatly@0.3.0:
+    dependencies:
+      fd-package-json: 2.0.0
 
   fsevents@2.3.3:
     optional: true
@@ -4103,6 +4546,26 @@ snapshots:
   keyv@4.5.4:
     dependencies:
       json-buffer: 3.0.1
+
+  knip@6.6.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      formatly: 0.3.0
+      get-tsconfig: 4.14.0
+      jiti: 2.6.1
+      minimist: 1.2.8
+      oxc-parser: 0.126.0
+      oxc-resolver: 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      picomatch: 4.0.4
+      smol-toml: 1.6.1
+      strip-json-comments: 5.0.3
+      tinyglobby: 0.2.16
+      unbash: 2.2.0
+      yaml: 2.8.3
+      zod: 4.3.6
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
 
   kolorist@1.8.0: {}
 
@@ -4300,6 +4763,57 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  oxc-parser@0.126.0:
+    dependencies:
+      '@oxc-project/types': 0.126.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.126.0
+      '@oxc-parser/binding-android-arm64': 0.126.0
+      '@oxc-parser/binding-darwin-arm64': 0.126.0
+      '@oxc-parser/binding-darwin-x64': 0.126.0
+      '@oxc-parser/binding-freebsd-x64': 0.126.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.126.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.126.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.126.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.126.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.126.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.126.0
+      '@oxc-parser/binding-linux-x64-musl': 0.126.0
+      '@oxc-parser/binding-openharmony-arm64': 0.126.0
+      '@oxc-parser/binding-wasm32-wasi': 0.126.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.126.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.126.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.126.0
+
+  oxc-resolver@11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0):
+    optionalDependencies:
+      '@oxc-resolver/binding-android-arm-eabi': 11.19.1
+      '@oxc-resolver/binding-android-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-arm64': 11.19.1
+      '@oxc-resolver/binding-darwin-x64': 11.19.1
+      '@oxc-resolver/binding-freebsd-x64': 11.19.1
+      '@oxc-resolver/binding-linux-arm-gnueabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm-musleabihf': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-arm64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-ppc64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-riscv64-musl': 11.19.1
+      '@oxc-resolver/binding-linux-s390x-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-gnu': 11.19.1
+      '@oxc-resolver/binding-linux-x64-musl': 11.19.1
+      '@oxc-resolver/binding-openharmony-arm64': 11.19.1
+      '@oxc-resolver/binding-wasm32-wasi': 11.19.1(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@oxc-resolver/binding-win32-arm64-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-ia32-msvc': 11.19.1
+      '@oxc-resolver/binding-win32-x64-msvc': 11.19.1
+    transitivePeerDependencies:
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+
   oxfmt@0.46.0:
     dependencies:
       tinypool: 2.1.0
@@ -4490,6 +5004,8 @@ snapshots:
       mrmime: 2.0.1
       totalist: 3.0.1
 
+  smol-toml@1.6.1: {}
+
   source-map-js@1.2.1: {}
 
   speakingurl@14.0.1: {}
@@ -4497,6 +5013,8 @@ snapshots:
   stable-hash-x@0.2.0: {}
 
   strip-bom@3.0.0: {}
+
+  strip-json-comments@5.0.3: {}
 
   superjson@2.2.6:
     dependencies:
@@ -4569,6 +5087,8 @@ snapshots:
   typescript@6.0.3: {}
 
   ufo@1.6.3: {}
+
+  unbash@2.2.0: {}
 
   undici-types@7.16.0: {}
 
@@ -4767,6 +5287,8 @@ snapshots:
     optionalDependencies:
       typescript: 6.0.3
 
+  walk-up-path@4.0.0: {}
+
   webpack-virtual-modules@0.6.2: {}
 
   whatwg-mimetype@3.0.0: {}
@@ -4794,3 +5316,5 @@ snapshots:
   yaml@2.8.3: {}
 
   yocto-queue@0.1.0: {}
+
+  zod@4.3.6: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -25,4 +25,5 @@ catalog:
 minimumReleaseAge: 4320
 
 minimumReleaseAgeExclude:
+  - '@miyaoka/eslint-plugin-barrel-import'
   - '@miyaoka/vite-plugin-doc-block'


### PR DESCRIPTION
## 概要

barrel-import ESLint プラグインによるスコープベースのインポート制御と、knip による未使用コード自動検出の仕組みを導入する。

## 背景

`apps/web/src/` の `shared/` と `features/` ディレクトリ間でファイル単位の直接インポートが行われており、各ディレクトリの公開インターフェースが不明確だった。また、未使用の export が残り続ける仕組みがなかった。

## 変更内容

### barrel-import ESLint プラグイン

- `@miyaoka/eslint-plugin-barrel-import` を追加
- `shared` スコープ（dependsOn: なし）と `features` スコープ（dependsOn: shared）で依存方向を制御
- `pnpm-workspace.yaml` の `minimumReleaseAgeExclude` にパッケージを追加

### バレルファイルの作成とインポート修正

- `shared/stores`, `shared/composables`, `shared/lib`, `shared/utils` に `index.ts` を作成
- `features/` 配下の全8ディレクトリに `index.ts` を作成
- 56箇所の直接インポートをバレル経由に書き換え

### knip の導入

- `knip.ts` でワークスペースごとの設定を定義
- lefthook pre-commit の piped ジョブに knip --fix を追加（oxlint + oxfmt の後に実行）
- knip --fix の変更は自動ステージせず unstaged で残る。ユーザーが確認して `git add` → 再コミットすると oxfmt がフォーマットを整える

### CLAUDE.md の更新

- Git フックのセクションにフォーマットや不要 export の整理はコミットフックで自動的に行われる旨を追記

## 確認事項

- [ ] 配信一覧の表示、フィルター操作、ブックマーク、ポップオーバーの動作確認
- [ ] lefthook pre-commit で knip --fix が正しく実行されるか
