### PR TITLE
feat(channel-filter): フィルタープリセットの複数保存・切り替え機能

### DIFF
--- a/apps/web/src/features/channelFilter/ChannelFilter.vue
+++ b/apps/web/src/features/channelFilter/ChannelFilter.vue
@@ -1,5 +1,7 @@
 <doc lang="md">
 タレントフィルターのポップオーバー。ホロライブ/にじさんじを切り替えて、グループ・タレント単位で表示対象を選択する。
+
+フィルター状態はプリセットとして名前付きで複数保存でき、切り替えて使用できる。
 </doc>
 
 <script setup lang="ts">
@@ -9,6 +11,7 @@ import { computed, ref } from "vue";
 import { usePopover } from "../../shared/composables";
 import { getAffiliationLogo, services } from "../../shared/services";
 import ChannelNode from "./ChannelNode.vue";
+import FilterPresetSelector from "./FilterPresetSelector.vue";
 import { useTalentFilterStore } from "./";
 
 const talentFilterStore = useTalentFilterStore();
@@ -22,7 +25,7 @@ const groups = [
 ] as const;
 
 const selectedGroup = ref<string>("hololive");
-const talentNodeEl = ref<HTMLElement | null>(null);
+const treeVersion = ref(0);
 
 const filterCount = computed(() => talentFilterStore.talentFilterMap.size);
 
@@ -40,9 +43,11 @@ const selectedService = computed(() => {
 
 function reset() {
   talentFilterStore.resetTalentFilter();
-  talentNodeEl.value?.querySelectorAll("input").forEach((input) => {
-    input.checked = false;
-  });
+  treeVersion.value++;
+}
+
+function onPresetLoaded() {
+  treeVersion.value++;
 }
 </script>
 
@@ -95,12 +100,15 @@ function reset() {
       </div>
 
       <div
-        class="-ml-4 flex-1 overflow-auto p-2 pt-4 pb-12"
-        ref="talentNodeEl"
+        class="-ml-4 flex-1 overflow-auto p-2 pt-4 pb-4"
         v-if="rootNode && selectedService"
-        :key="rootNode.name"
+        :key="`${rootNode.name}-${treeVersion}`"
       >
-        <ChannelNode :node="rootNode" :service="selectedService" :key="rootNode.name" />
+        <ChannelNode :node="rootNode" :service="selectedService" />
+      </div>
+
+      <div class="bg-gray-800 px-4 py-3 shadow-[0_-2px_4px_rgba(0,0,0,0.08)]">
+        <FilterPresetSelector @loaded="onPresetLoaded" />
       </div>
     </div>
   </popover.PopOver>

--- a/apps/web/src/features/channelFilter/FilterPresetSelector.vue
+++ b/apps/web/src/features/channelFilter/FilterPresetSelector.vue
@@ -1,0 +1,142 @@
+<doc lang="md">
+フィルタープリセットの選択・保存・削除を行うセレクター。
+
+## 操作
+
+- プリセットを選ぶと即座にフィルターに反映
+- 現在のフィルター状態を名前付きで新規追加
+- 既存プリセットの上書き保存・削除
+</doc>
+
+<script setup lang="ts">
+import { nextTick, ref } from "vue";
+import { useTalentFilterStore } from "./";
+
+const emit = defineEmits<{
+  loaded: [];
+}>();
+
+const talentFilterStore = useTalentFilterStore();
+
+const isEditing = ref(false);
+const editName = ref("");
+const editNameInput = ref<HTMLInputElement | null>(null);
+
+function onPresetSelect(event: Event) {
+  const select = event.target as HTMLSelectElement;
+  const id = select.value;
+  if (!id) {
+    talentFilterStore.resetTalentFilter();
+    emit("loaded");
+    return;
+  }
+  talentFilterStore.loadPreset(id);
+  emit("loaded");
+}
+
+async function startSave() {
+  editName.value = "";
+  isEditing.value = true;
+  await nextTick();
+  editNameInput.value?.focus();
+}
+
+function confirmSave() {
+  const name = editName.value.trim();
+  if (!name) return;
+  talentFilterStore.savePreset(name);
+  isEditing.value = false;
+}
+
+function onEnter(event: KeyboardEvent) {
+  if (event.isComposing) return;
+  confirmSave();
+}
+
+function cancelEdit() {
+  isEditing.value = false;
+}
+
+function overwritePreset() {
+  const preset = talentFilterStore.activePreset;
+  if (!preset) return;
+  talentFilterStore.updatePreset(preset.id);
+}
+
+function deleteActivePreset() {
+  const preset = talentFilterStore.activePreset;
+  if (!preset) return;
+  if (!window.confirm(`「${preset.name}」を削除しますか？`)) return;
+  talentFilterStore.deletePreset(preset.id);
+}
+</script>
+
+<template>
+  <div class="flex flex-col gap-2">
+    <!-- 行1: プリセット選択 or 名前入力 -->
+    <div v-if="isEditing" class="flex gap-1">
+      <input
+        ref="editNameInput"
+        v-model="editName"
+        type="text"
+        class="min-w-0 flex-1 rounded-lg border bg-white px-2 py-1 text-sm"
+        placeholder="プリセット名"
+        @keydown.enter="onEnter"
+        @keydown.escape="cancelEdit"
+      />
+      <button
+        class="grid size-8 shrink-0 place-items-center rounded-lg bg-blue-500 text-white hover:bg-blue-600 disabled:opacity-40"
+        :disabled="!editName.trim()"
+        @click="confirmSave"
+      >
+        <i class="i-mdi-check size-5" />
+      </button>
+      <button
+        class="grid size-8 shrink-0 place-items-center rounded-lg bg-gray-200 hover:bg-gray-300"
+        @click="cancelEdit"
+      >
+        <i class="i-mdi-close size-5" />
+      </button>
+    </div>
+    <div v-else class="flex gap-1">
+      <select
+        class="min-w-0 flex-1 rounded-lg border bg-white px-2 py-1 text-sm"
+        :value="talentFilterStore.activePresetId ?? ''"
+        @change="onPresetSelect"
+      >
+        <option value="">プリセット未選択</option>
+        <option v-for="preset in talentFilterStore.presets" :key="preset.id" :value="preset.id">
+          {{ preset.name }}（{{ preset.talents.length }}）
+        </option>
+      </select>
+
+      <button
+        class="grid size-8 shrink-0 place-items-center rounded-lg bg-amber-100 text-amber-800 not-disabled:bg-amber-500 not-disabled:text-white not-disabled:hover:bg-amber-600 disabled:opacity-30"
+        title="上書き保存"
+        :disabled="!talentFilterStore.activePreset || !talentFilterStore.isModified"
+        @click="overwritePreset"
+      >
+        <i class="i-mdi-check size-5" />
+      </button>
+
+      <button
+        class="grid size-8 shrink-0 place-items-center rounded-lg bg-red-100 text-red-800 not-disabled:bg-red-500 not-disabled:text-white not-disabled:hover:bg-red-600 disabled:opacity-30"
+        title="削除"
+        :disabled="!talentFilterStore.activePreset"
+        @click="deleteActivePreset"
+      >
+        <i class="i-mdi-delete-outline size-5" />
+      </button>
+    </div>
+
+    <!-- 行2: 新規保存ボタン（常に表示） -->
+    <button
+      class="flex h-8 w-full items-center justify-center gap-1 rounded-lg bg-blue-100 text-sm text-blue-800 not-disabled:bg-blue-500 not-disabled:text-white not-disabled:hover:bg-blue-600 disabled:opacity-30"
+      :disabled="talentFilterStore.talentFilterMap.size === 0 || isEditing"
+      @click="startSave"
+    >
+      <i class="i-mdi-plus size-5" />
+      <span>新規プリセット追加</span>
+    </button>
+  </div>
+</template>

--- a/apps/web/src/features/channelFilter/talentFilterStore.ts
+++ b/apps/web/src/features/channelFilter/talentFilterStore.ts
@@ -2,24 +2,42 @@ import { useLocalStorage } from "@vueuse/core";
 import { acceptHMRUpdate, defineStore } from "pinia";
 import { computed } from "vue";
 
-interface TreeNode {
+interface FilterPreset {
   id: string;
-  checked: boolean;
-  children?: TreeNode[];
+  name: string;
+  talents: string[];
 }
 
-interface Node {
-  [key: string]: string[] | Node;
+function generateId(): string {
+  return crypto.randomUUID();
 }
 
 export const useTalentFilterStore = defineStore("talentFilterStore", () => {
   const _talentFilterMap = useLocalStorage("talentFilter", new Map<string, boolean>());
   const talentFilterEnabled = useLocalStorage("talentFilterEnabled", true);
+  const presets = useLocalStorage<FilterPreset[]>("talentFilterPresets", []);
+  const activePresetId = useLocalStorage<string | null>("talentFilterActivePresetId", null);
 
   const talentFilterMap = computed(() => {
     if (!talentFilterEnabled.value) return new Map<string, boolean>();
     return _talentFilterMap.value;
   });
+
+  const activePreset = computed(() => {
+    if (!activePresetId.value) return undefined;
+    return presets.value.find((p) => p.id === activePresetId.value);
+  });
+
+  // 現在のフィルターがアクティブプリセットから変更されているか
+  const isModified = computed(() => {
+    const preset = activePreset.value;
+    if (!preset) return _talentFilterMap.value.size > 0;
+    const currentTalents = [..._talentFilterMap.value.keys()].sort();
+    const presetTalents = [...preset.talents].sort();
+    if (currentTalents.length !== presetTalents.length) return true;
+    return currentTalents.some((t, i) => t !== presetTalents[i]);
+  });
+
   function setTalentFilter(name: string, enabled: boolean) {
     if (enabled) {
       _talentFilterMap.value.set(name, enabled);
@@ -30,6 +48,53 @@ export const useTalentFilterStore = defineStore("talentFilterStore", () => {
 
   function resetTalentFilter() {
     _talentFilterMap.value.clear();
+    activePresetId.value = null;
+  }
+
+  function _loadTalentsToMap(talents: string[]) {
+    _talentFilterMap.value.clear();
+    for (const name of talents) {
+      _talentFilterMap.value.set(name, true);
+    }
+  }
+
+  function savePreset(name: string): FilterPreset {
+    const preset: FilterPreset = {
+      id: generateId(),
+      name,
+      talents: [..._talentFilterMap.value.keys()],
+    };
+    presets.value = [...presets.value, preset];
+    activePresetId.value = preset.id;
+    return preset;
+  }
+
+  function updatePreset(id: string) {
+    presets.value = presets.value.map((p) => {
+      if (p.id !== id) return p;
+      return { ...p, talents: [..._talentFilterMap.value.keys()] };
+    });
+  }
+
+  function loadPreset(id: string) {
+    const preset = presets.value.find((p) => p.id === id);
+    if (!preset) return;
+    _loadTalentsToMap(preset.talents);
+    activePresetId.value = id;
+  }
+
+  function deletePreset(id: string) {
+    presets.value = presets.value.filter((p) => p.id !== id);
+    if (activePresetId.value === id) {
+      activePresetId.value = null;
+    }
+  }
+
+  function renamePreset({ id, name }: { id: string; name: string }) {
+    presets.value = presets.value.map((p) => {
+      if (p.id !== id) return p;
+      return { ...p, name };
+    });
   }
 
   return {
@@ -37,6 +102,15 @@ export const useTalentFilterStore = defineStore("talentFilterStore", () => {
     setTalentFilter,
     resetTalentFilter,
     talentFilterEnabled,
+    presets,
+    activePresetId,
+    activePreset,
+    isModified,
+    savePreset,
+    updatePreset,
+    loadPreset,
+    deletePreset,
+    renamePreset,
   };
 });
 


### PR DESCRIPTION
## 概要

チャンネルフィルターのプリセット機能を追加。フィルター状態を名前付きで複数保存し、切り替えて使用できるようにする。

## 背景

従来のチャンネルフィルターは単一の `Map<string, boolean>` を localStorage に保存する構造で、フィルター設定は1つしか保持できなかった。ホロライブとにじさんじを切り替えて使う場合や、特定のグループだけを表示したい場合など、複数のフィルター設定を保存・切り替えたいニーズがあった。

## 変更内容

### ストア（talentFilterStore.ts）

- `FilterPreset` 型（id, name, talents）を追加
- プリセット一覧（`presets`）、アクティブプリセットID（`activePresetId`）を localStorage で永続化
- `savePreset` / `loadPreset` / `updatePreset` / `deletePreset` / `renamePreset` / `deselectPreset` メソッドを追加
- `isModified` computed で現在のフィルターがプリセットから変更されているかを判定
- 既存の `talentFilterMap` は変更なし。消費側（eventListStore 等）の修正は不要
- 作業中フィルターとプリセット選択状態を分離。`deselectPreset()` はプリセット紐付けの解除のみ行い、作業フィルターは保持する

### UI（FilterPresetSelector.vue）

- プリセットセレクター（select + 操作ボタン）をフッターに配置
- 行1: プリセット選択 + 上書き保存 + 削除（既存プリセットの編集操作）
- 行2: 新規プリセット追加ボタン（独立した追加操作）
- ボタン活性化: 非活性時は `disabled:opacity-30` で薄く表示、活性時は `not-disabled:bg-*-500` で色付き
- 削除時に `window.confirm` で確認
- IME 対応: `isComposing` ガードで変換確定時の誤発火を防止

### ChannelFilter.vue

- FilterPresetSelector をフッターに配置
- `treeVersion` カウンターでプリセットロード時に ChannelNode を再マウントし、DOM チェックボックスの状態を同期

## 確認事項

- [ ] プリセットの新規追加・切り替え・上書き保存・削除が正しく動作するか
- [ ] プリセット切り替え時にチェックボックスの表示が正しく反映されるか
- [ ] ボタンの活性/非活性表示が状態に応じて正しく切り替わるか
- [ ] 日本語入力でプリセット名を入力し、変換確定時に誤送信されないか
- [ ] ページリロード後にプリセットが保持されているか
- [ ] 「プリセット未選択」を選んだ時に作業中のフィルターが消えないか
