### PR TITLE
fix(pnpm): minimumReleaseAgeStrict を false にして time 欠損パッケージで install が落ちないようにする

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -23,6 +23,7 @@ catalog:
   vite: 8.0.10
 
 minimumReleaseAge: 4320
+minimumReleaseAgeStrict: false
 
 minimumReleaseAgeExclude:
   - '@miyaoka/eslint-plugin-barrel-import'


### PR DESCRIPTION
## 概要

`pnpm-workspace.yaml` に `minimumReleaseAgeStrict: false` を追加し、npm レジストリで `time` フィールドが提供されていないパッケージを age チェックから除外する。

## 背景

pnpm 11.0.4 以降、`minimumReleaseAge` を有効にしている状態で、npm レジストリのメタデータに `time` フィールドが欠けているパッケージを解決しようとすると `ERR_PNPM_MISSING_TIME` で install が中断するようになった。

このリポジトリでは catalog で `@types/bun` を使用しており、その依存である `bun-types` が `time` フィールドを提供していないため、Renovate の lockfile 更新が常に失敗していた（ #471 等）。

```text
[ERR_PNPM_MISSING_TIME] The metadata of bun-types is missing the "time" field
This error happened while installing the dependencies of @types/bun@1.3.13
```

`minimumReleaseAgeStrict: false` を設定すると、`time` 欠損パッケージは age チェックを skip して通過するようになり、レジストリ起因のエラーで install 全体が落ちることがなくなる。age 制限を当てたい本来のターゲット（time を返す通常の npm パッケージ）には引き続き有効。

## 変更内容

### pnpm 設定

- `pnpm-workspace.yaml` に `minimumReleaseAgeStrict: false` を追加

## 確認事項

- [ ] Renovate の次回ジョブで lockfile 更新が成功すること（既存の Artifact update problem PR が retry で復旧する）
- [ ] ローカルで `pnpm install` がエラーなく完了すること
