### PR TITLE
ci(update-channels): PAT を GitHub App インストールトークンに置換

### DIFF
--- a/.github/workflows/update-channels.yml
+++ b/.github/workflows/update-channels.yml
@@ -35,7 +35,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          client-id: ${{ secrets.APP_CLIENT_ID }}
+          client-id: ${{ secrets.CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           # 必要権限をコードで宣言し、App インストール権限への暗黙依存をなくす（SSOT）。
           # push に contents:write、PR 作成と auto-merge に pull-requests:write が要る。

--- a/.github/workflows/update-channels.yml
+++ b/.github/workflows/update-channels.yml
@@ -10,9 +10,10 @@ jobs:
   update:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    # PR 作成・auto-merge は App トークンが担うため、デフォルト GITHUB_TOKEN は
+    # checkout の fetch に必要な read のみに絞る。
     permissions:
-      contents: write
-      pull-requests: write
+      contents: read
 
     steps:
       - name: Checkout code
@@ -27,11 +28,21 @@ jobs:
       - name: Update hololive channels
         run: pnpm --filter @liver-streams/hololive update-channels
 
+      # GitHub App の短命インストールトークンを発行する。
+      # デフォルトの GITHUB_TOKEN で作った PR は CI / auto-merge を発火させないため、
+      # 別 actor のトークンが必要。長命な PAT の代わりに App トークンを使う。
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
-          token: ${{ secrets.PAT }}
+          token: ${{ steps.app-token.outputs.token }}
           branch: update-channels
           title: チャンネル情報を更新
           body: 自動更新により新規チャンネルを検出しました。
@@ -41,4 +52,4 @@ jobs:
         if: steps.cpr.outputs.pull-request-operation == 'created'
         run: gh pr merge --auto --squash "${{ steps.cpr.outputs.pull-request-number }}"
         env:
-          GH_TOKEN: ${{ secrets.PAT }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/update-channels.yml
+++ b/.github/workflows/update-channels.yml
@@ -35,14 +35,21 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ secrets.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          # 必要権限をコードで宣言し、App インストール権限への暗黙依存をなくす（SSOT）。
+          # push に contents:write、PR 作成と auto-merge に pull-requests:write が要る。
+          permission-contents: write
+          permission-pull-requests: write
 
       - name: Create Pull Request
         id: cpr
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ steps.app-token.outputs.token }}
+          # API 経由で署名コミットを作り、author/committer を App bot に統一する。
+          # 未指定だと author が github.actor（schedule 実行時は個人）になり個人依存が残る。
+          sign-commits: true
           branch: update-channels
           title: チャンネル情報を更新
           body: 自動更新により新規チャンネルを検出しました。


### PR DESCRIPTION
## 概要

`update-channels` ワークフローの認証を、長命な Personal Access Token (PAT) から GitHub App のインストールトークンに置き換える。あわせてトークンの権限明示・コミット主体の統一・デフォルト `GITHUB_TOKEN` 権限の最小化を行う。

## 背景

このワークフローは PR の自動作成と auto-merge を行うため、`secrets.PAT` を `create-pull-request` の `token` と auto-merge の `GH_TOKEN` に使っていた。

PAT が必要だった理由は、デフォルトの `GITHUB_TOKEN` で作成した PR が `on: push` / `on: pull_request` を発火させない GitHub の仕様にある。このイベント抑制は actor (`github-actions[bot]`) で判定されるため、別 actor のトークンであれば CI は発火する。App インストールトークンも PAT と同様に CI を発火でき、auto-merge の前提（必須チェックの green 化）を満たせる。

PAT は個人アカウント紐づき・スコープが粗い・無期限運用も可能で、漏洩時の影響範囲と期間が大きい。App インストールトークンは短命 (ジョブ終了で失効)・細粒度スコープ・App 紐づきで、PAT の発火要件を満たしつつこれらの弱点を解消する。2026 年現在の推奨アプローチ。

## 変更内容

### 認証

- `actions/create-github-app-token@v3.2.0` ( SHA ピン ) で App インストールトークンを発行するステップを追加
- `create-pull-request` の `token` と auto-merge の `GH_TOKEN` を `secrets.PAT` から `steps.app-token.outputs.token` に置換
- トークン発行入力は deprecated な `app-id` ではなく `client-id` ( `secrets.CLIENT_ID` ) を使用
- `permission-contents: write` / `permission-pull-requests: write` を明示宣言し、必要権限を App インストール設定への暗黙依存ではなくコード側で固定 ( SSOT )

### コミット主体

- `sign-commits: true` を有効化。署名コミットを GitHub API 経由で作成し、author/committer を App bot に統一する ( 未指定だと author が `github.actor` ＝ schedule 実行時は個人になり、個人依存が残るため )

### 権限

- PR 作成権限が App トークン側へ移ったため、ジョブの `permissions` を `contents: write` / `pull-requests: write` から checkout の fetch に必要な `contents: read` のみに縮小

## 確認事項

- [ ] `secrets.CLIENT_ID` ( App の Client ID ) と `secrets.APP_PRIVATE_KEY` を登録すること。`client-id` 採用に伴い旧 `APP_ID` secret は不要
- [ ] App が対象リポジトリにインストール済みで Contents / Pull requests が write 権限であること
- [ ] main マージ後に手動実行 ( `gh workflow run update-channels.yml` ) し、App トークン発行 → PR 作成 → auto-merge が通ること
- [ ] 動作確認後に旧 `secrets.PAT` を削除すること

